### PR TITLE
set GOOS and CGO_ENABLED flag when build aws-appmesh CNI plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ $(BUILD_DIR)/vpc-branch-pat-eni: $(VPC_BRANCH_PAT_ENI_PLUGIN_SOURCE_FILES) $(COM
 
 # Build the aws-appmesh CNI plugin.
 $(BUILD_DIR)/aws-appmesh: $(AWS_APPMESH_PLUGIN_SOURCE_FILES) $(COMMON_SOURCE_FILES)
-	go build \
+	GOOS=linux CGO_ENABLED=0 go build \
 		-installsuffix cgo \
 		-v \
 		-a \


### PR DESCRIPTION
*Description of changes:*
Set GOOS and CGO_ENABLED flag when build aws-appmesh CNI plugin, so we can support cross platform compilation and build static binaries.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
