### PR TITLE
vpc-branch-eni plugin: use gateway ip address if specified in netconfig

### DIFF
--- a/plugins/vpc-branch-eni/config/netconfig_test.go
+++ b/plugins/vpc-branch-eni/config/netconfig_test.go
@@ -16,6 +16,7 @@
 package config
 
 import (
+	"net"
 	"testing"
 
 	"github.com/containernetworking/cni/pkg/skel"
@@ -101,4 +102,26 @@ func TestPerContainerArgsOverrideNetConfig(t *testing.T) {
 	assert.Equal(t, 42, nc.BranchVlanID, "invalid vlanid")
 	assert.Equal(t, "44:44:44:55:55:55", nc.BranchMACAddress.String(), "invalid macaddress")
 	assert.Equal(t, "192.168.1.2/16", nc.BranchIPAddress.String(), "invalid ipaddress")
+}
+
+func TestGetGatewayIPAddress(t *testing.T) {
+	_, ipv4Net, err := net.ParseCIDR("172.31.16.3/20")
+	assert.NoError(t, err)
+
+	expectedGatewayIPAddress := net.ParseIP("172.31.16.2")
+
+	outputGatewayIPAddress, err := getGatewayIPAddress(ipv4Net, "172.31.16.2")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedGatewayIPAddress, outputGatewayIPAddress)
+}
+
+func TestGetGatewayIPAddressFromSubnet(t *testing.T) {
+	_, ipv4Net, err := net.ParseCIDR("172.31.16.3/20")
+	assert.NoError(t, err)
+
+	expectedGatewayIPAddress := net.ParseIP("172.31.16.1")
+
+	outputGatewayIPAddress, err := getGatewayIPAddress(ipv4Net, "")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedGatewayIPAddress, outputGatewayIPAddress)
 }

--- a/plugins/vpc-branch-eni/plugin/commands.go
+++ b/plugins/vpc-branch-eni/plugin/commands.go
@@ -107,7 +107,7 @@ func (plugin *Plugin) Add(args *cniSkel.CmdArgs) error {
 		switch netConfig.InterfaceType {
 		case config.IfTypeVLAN:
 			// Container is running in a network namespace on this host.
-			err = plugin.createVLANLink(branch, args.IfName, netConfig.BranchIPAddress)
+			err = plugin.createVLANLink(branch, args.IfName, netConfig.BranchIPAddress, netConfig.BranchGatewayIPAddress)
 		case config.IfTypeTAP:
 			// Container is running in a VM.
 			// Connect the branch ENI to a TAP link in the target network namespace.
@@ -246,7 +246,7 @@ func (plugin *Plugin) Del(args *cniSkel.CmdArgs) error {
 }
 
 // createVLANLink creates a VLAN link in the target network namespace.
-func (plugin *Plugin) createVLANLink(branch *eni.Branch, linkName string, ipAddress *net.IPNet) error {
+func (plugin *Plugin) createVLANLink(branch *eni.Branch, linkName string, ipAddress *net.IPNet, gatewayIPAddress net.IP) error {
 	// Rename the branch link to the requested interface name.
 	log.Infof("Renaming branch link %v to %s.", branch, linkName)
 	err := branch.SetLinkName(linkName)
@@ -273,16 +273,9 @@ func (plugin *Plugin) createVLANLink(branch *eni.Branch, linkName string, ipAddr
 			return err
 		}
 
-		// Parse VPC subnet.
-		subnet, err := vpc.NewSubnet(vpc.GetSubnetPrefix(ipAddress))
-		if err != nil {
-			log.Errorf("Failed to parse VPC subnet for %s: %v.", ipAddress, err)
-			return err
-		}
-
 		// Add default route via branch link.
 		route := &netlink.Route{
-			Gw:        subnet.Gateways[0],
+			Gw:        gatewayIPAddress,
 			LinkIndex: branch.GetLinkIndex(),
 		}
 		log.Infof("Adding default IP route %+v.", route)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use gateway ip address if specified in netconfig for vpc-branch-eni. Previously the branchGatewayIPAddress field in NetConfig of vpc-branch-eni can be provided but was never used, and the gateway ip was always inferred from the subnet. Existing behavior of ecs task networking is to supply the gateway ip address to ecs-eni plugin with the value specified in acs payload, and that will be the gateway ip to use. To use vpc-branch-eni plugin in eni trunking, we need to maintain the same behavior. This PR makes the necessary changes for that in the plugin.

### Testing
Manually tested this by specifying a non-default gateway ip "172.31.16.2" in branchGatewayIPAddress field, and verified that the gateway ip is used in container's network namespace:
```
[ec2-user@ip-172-31-17-155 ecs]$ sudo nsenter -t ${PID} -n route -n
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
0.0.0.0         172.31.16.2     0.0.0.0         UG    0      0        0 eth0
169.254.170.2   169.254.172.1   255.255.255.255 UGH   0      0        0 ecs-eth0
169.254.172.1   169.254.172.1   255.255.255.255 UGH   0      0        0 ecs-eth0
172.31.16.0     0.0.0.0         255.255.240.0   U     0      0        0 eth0
```

Also found the following logs:
```
...
2019-02-27T18:48:04Z [INFO] Setting branch link state up.
2019-02-27T18:48:04Z [INFO] Assigning IP address 172.31.18.203/20 to branch link.
2019-02-27T18:48:04Z [INFO] Using gateway ip specified in NetConfig: 172.31.16.2
2019-02-27T18:48:04Z [INFO] Adding default IP route {Ifindex: 56 Dst: <nil> Src: <nil> Gw: 172.31.16.2 Flags: [] Table: 0}.
...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
