### PR TITLE
Remove GOARCH to support multi-arch build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,6 @@ LINKER_FLAGS = "\
 		-X github.com/aws/amazon-vpc-cni-plugins/version.BuildTime=$(BUILD_TIMESTAMP) \
 		-s"
 
-
 # Source files.
 COMMON_SOURCE_FILES = $(wildcard cni/*.go, logger/*.go, network/*.go, version/*.go)
 VPC_SHARED_ENI_PLUGIN_SOURCE_FILES = $(shell find plugins/vpc-shared-eni -type f)
@@ -94,7 +93,7 @@ $(BUILD_DIR)/vpc-branch-pat-eni: $(VPC_BRANCH_PAT_ENI_PLUGIN_SOURCE_FILES) $(COM
 
 # Build the aws-appmesh CNI plugin.
 $(BUILD_DIR)/aws-appmesh: $(AWS_APPMESH_PLUGIN_SOURCE_FILES) $(COMMON_SOURCE_FILES)
-	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=$(CGO_ENABLED) \
+	GOOS=$(GOOS) CGO_ENABLED=$(CGO_ENABLED) \
 	go build \
 		-installsuffix cgo \
 		-v \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove GOARCH to support multi-arch build. We have an issue that compiled binary can't be executed on AL2 ARM.
````
2019-02-27T20:51:39Z [INFO] Restored cluster 'default'
2019-02-27T20:51:39Z [CRITICAL] Unable to initialize Task ENI dependencies: ecscni: failed invoking capabilities command for 'aws-appmesh': fork/exec /amazon-ecs-cni-plugins/aws-appmesh: exec format error
````


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
