### PR TITLE
Remove IgnoredUID/IgnoredGID validation in aws-appmesh

### DIFF
--- a/plugins/aws-appmesh/config/netconfig.go
+++ b/plugins/aws-appmesh/config/netconfig.go
@@ -114,12 +114,6 @@ func validateConfig(config netConfigJSON) error {
 	}
 
 	// Validate the format of all fields.
-	if err := isValidID(config.IgnoredGID); err != nil {
-		return err
-	}
-	if err := isValidID(config.IgnoredUID); err != nil {
-		return err
-	}
 	if err := isValidPort(config.ProxyEgressPort); err != nil {
 		return err
 	}
@@ -165,20 +159,6 @@ func separateIPs(ignoredIPs []string) (string, string, error) {
 
 	}
 	return strings.Join(ipv4s, splitter), strings.Join(ipv6s, splitter), nil
-}
-
-// isValidID checks whether the id only has digits.
-func isValidID(id string) error {
-	if id == "" {
-		return nil
-	}
-
-	i, err := strconv.Atoi(id)
-	if err == nil && i > 0 {
-		return nil
-	}
-
-	return errors.Errorf("invalid uid/gid [%s] specified", id)
 }
 
 // isValidPort checks whether the port only has digits.

--- a/plugins/aws-appmesh/config/netconfig_test.go
+++ b/plugins/aws-appmesh/config/netconfig_test.go
@@ -112,37 +112,10 @@ func TestSeparateIPsFailure(t *testing.T) {
 	}
 }
 
-func TestIsValidIDWithValidID(t *testing.T) {
-	ids := []string{"1", "311"}
-	for _, id := range ids {
-		result := isValidID(id)
-		assert.NoError(t, result)
-	}
-}
-
-func TestIsValidIDWithInvalidID(t *testing.T) {
-	type ID struct {
-		id             string
-		expectedResult string
-	}
-
-	ids := []ID{
-		{id: "a", expectedResult: "invalid uid/gid [a] specified"},
-		{id: "1*ab", expectedResult: "invalid uid/gid [1*ab] specified"},
-		{id: " 1", expectedResult: "invalid uid/gid [ 1] specified"},
-		{id: "-1", expectedResult: "invalid uid/gid [-1] specified"},
-		{id: "1.1", expectedResult: "invalid uid/gid [1.1] specified"},
-	}
-	for _, id := range ids {
-		result := isValidID(id.id)
-		assert.Equal(t, id.expectedResult, result.Error())
-	}
-}
-
 func TestIsValidPortWithValidPort(t *testing.T) {
 	ports := []string{"1337", "311"}
 	for _, port := range ports {
-		result := isValidID(port)
+		result := isValidPort(port)
 		assert.NoError(t, result)
 	}
 }


### PR DESCRIPTION
*Description of changes:*
Confirmed that iptables uid-owner/gid-owner can take both userid/groupid and numeric UID/GID. So remove the validation for IgnoredUID/IgnoredGID.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
