### PR TITLE
vpc-branch-eni: remove GOARCH to support multi-arch build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ $(BUILD_DIR)/vpc-shared-eni: $(VPC_SHARED_ENI_PLUGIN_SOURCE_FILES) $(COMMON_SOUR
 
 # Build the vpc-branch-eni CNI plugin.
 $(BUILD_DIR)/vpc-branch-eni: $(VPC_BRANCH_ENI_PLUGIN_SOURCE_FILES) $(COMMON_SOURCE_FILES)
-	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=$(CGO_ENABLED) \
+	GOOS=$(GOOS) CGO_ENABLED=$(CGO_ENABLED) \
 	go build \
 		-installsuffix cgo \
 		-v \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Similar to https://github.com/aws/amazon-vpc-cni-plugins/pull/4, vpc-branch-eni was not working properly on arm because of the GOARCH flag. Using a binary built from that ends up with the following error on arm:
```
2019-03-05T00:36:19Z [CRITICAL] Unable to initialize Task ENI dependencies: ecscni: failed invoking capabilities command for 'vpc-branch-eni': fork/exec /amazon-ecs-cni-plugins/vpc-branch-eni: exec format error
```
Fixing it by removing the GOARCH flag. I've tested the fix in one of agent's pr - https://github.com/aws/amazon-ecs-agent/pull/1920, in which the arm functional tests passed with the fix, and failed without it.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
