### PR TITLE
Add GOARCH to aws-appmesh build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ $(BUILD_DIR)/vpc-branch-pat-eni: $(VPC_BRANCH_PAT_ENI_PLUGIN_SOURCE_FILES) $(COM
 
 # Build the aws-appmesh CNI plugin.
 $(BUILD_DIR)/aws-appmesh: $(AWS_APPMESH_PLUGIN_SOURCE_FILES) $(COMMON_SOURCE_FILES)
-	GOOS=$(GOOS) CGO_ENABLED=$(CGO_ENABLED) \
+	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=$(CGO_ENABLED) \
 	go build \
 		-installsuffix cgo \
 		-v \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We added GOARCH as a environment variable to build amazon-vpc-cni-plugins [here](https://github.com/aws/amazon-ecs-agent/pull/1920/files#diff-68e77808f782cc71763dc5288e863117R19) as part of [this pr](https://github.com/aws/amazon-ecs-agent/pull/1920). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
