### PR TITLE
vpc-shared-eni: Use annotations instead of labels

### DIFF
--- a/plugins/vpc-shared-eni/config/kubernetes.go
+++ b/plugins/vpc-shared-eni/config/kubernetes.go
@@ -108,8 +108,8 @@ func parseKubernetesArgs(netConfig *NetConfig, args *cniSkel.CmdArgs) error {
 			return fmt.Errorf("failed to get pod %s: %v", kc.PodName, err)
 		}
 
-		podLabels := pod.GetLabels()
-		ipAddress, _ = podLabels[vpcResourceNameIPAddress]
+		podAnnotations := pod.GetAnnotations()
+		ipAddress, _ = podAnnotations[vpcResourceNameIPAddress]
 		if ipAddress != "" {
 			break
 		}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Use annotations instead of labels to assign IP address for pods. 

*Testing:*
Manually updated the plugin on the instance to validate the changes. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Vinothkumar Siddharth <sidvin@amazon.com>