### PR TITLE
Fix a race condition in getting the trunk name via its mac

### DIFF
--- a/network/eni/eni_test.go
+++ b/network/eni/eni_test.go
@@ -1,0 +1,53 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package eni
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetInterfaceByMacAddress(t *testing.T) {
+	mac1, _ := net.ParseMAC("12:34:56:78:9a:bc")
+	mac2, _ := net.ParseMAC("cb:a9:87:65:43:21")
+
+	interfaces := []net.Interface{
+		{
+			Index: 1,
+			Name: "eth1.1",
+			HardwareAddr: mac1,
+		},
+		{
+			Index: 2,
+			Name: "eth1",
+			HardwareAddr: mac1,
+		},
+		{
+			Index: 3,
+			Name: "eth1.1.1",
+			HardwareAddr: mac1,
+		},
+		{
+			Index: 4,
+			Name: "eth",
+			HardwareAddr: mac2,
+		},
+	}
+
+	chosenInterface := getInterfaceByMACAddress(mac1, interfaces)
+	assert.NotNil(t, chosenInterface)
+	assert.Equal(t, "eth1", chosenInterface.Name)
+}


### PR DESCRIPTION
During setting up a branch interface, the branch can have the same mac address as the trunk for a short period of time, and we may end up picking the branch's name when trying to get the trunk name by mac. Fixing it by picking the shortest name available since branch name is strictly longer than trunk.

Unit test added and passed. The e2e tests via vpc-branch-eni-e2e-tests target passed. Manual test in progress.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
