### PR TITLE
Validate interface type in vpc-shared-eni on Linux

### DIFF
--- a/plugins/vpc-shared-eni/config/netconfig.go
+++ b/plugins/vpc-shared-eni/config/netconfig.go
@@ -95,6 +95,7 @@ func New(args *cniSkel.CmdArgs) (*NetConfig, error) {
 		NetConf:         config.NetConf,
 		ENIName:         config.ENIName,
 		BridgeNetNSPath: config.BridgeNetNSPath,
+		InterfaceType:   config.InterfaceType,
 		Kubernetes: KubernetesConfig{
 			ServiceCIDR: config.ServiceCIDR,
 		},
@@ -141,6 +142,11 @@ func New(args *cniSkel.CmdArgs) (*NetConfig, error) {
 		if netConfig.GatewayIPAddress == nil {
 			return nil, fmt.Errorf("invalid GatewayIPAddress %s", config.GatewayIPAddress)
 		}
+	}
+
+	// Parse the interface type.
+	if config.InterfaceType != IfTypeVETH && config.InterfaceType != IfTypeTAP {
+		return nil, fmt.Errorf("invalid InterfaceType %s", config.InterfaceType)
 	}
 
 	// Parse the optional TAP user ID.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Vpc-shared-eni plugin should validate the interface type specified in the netconfig file on Linux. The parameter is not applicable to Windows.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
