### PR TITLE
vpc-branch-eni: bring up trunk interface before configuring branch

### DIFF
--- a/plugins/vpc-branch-eni/e2eTests/e2e_test.go
+++ b/plugins/vpc-branch-eni/e2eTests/e2e_test.go
@@ -37,6 +37,7 @@ const (
 	ifName                 = "testIf"
 	nsName                 = "testNS"
 	trunkMACAddress        = "02:71:ca:81:41:1e"
+	trunkName              = "eth1"
 	branchVlanID           = "101"
 	branchMACAddress       = "02:e1:48:75:86:a4"
 	branchIPAddress        = "172.31.19.6/20"
@@ -73,6 +74,16 @@ func TestAddDelBlockIMDS(t *testing.T) {
 }
 
 func TestAddDel(t *testing.T) {
+	var err error
+
+	// Bring down the trunk interface so that we can ensure the plugin is not assuming the trunk interface
+	// is already brought up.
+	la := netlink.NewLinkAttrs()
+	la.Name = trunkName
+	link := &netlink.Dummy{LinkAttrs: la}
+	err = netlink.LinkSetDown(link)
+	require.NoError(t, err)
+
 	testAddDel(t, netConfJsonFmt, validateAfterAdd, validateAfterDel)
 }
 

--- a/plugins/vpc-branch-eni/plugin/commands.go
+++ b/plugins/vpc-branch-eni/plugin/commands.go
@@ -74,6 +74,13 @@ func (plugin *Plugin) Add(args *cniSkel.CmdArgs) error {
 		return err
 	}
 
+	// Bring up the trunk ENI.
+	err = trunk.SetOpState(true)
+	if err != nil {
+		log.Errorf("Failed to bring up trunk interface %s: %v", netConfig.TrunkName, err)
+		return err
+	}
+
 	// Create the branch ENI.
 	branchName := fmt.Sprintf(branchLinkNameFormat, trunk.GetLinkName(), netConfig.BranchVlanID)
 	branch, err := eni.NewBranch(trunk, branchName, netConfig.BranchMACAddress, netConfig.BranchVlanID)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We are previously assuming that trunk interface is always up, and for eni trunking, we implicitly rely on ec2-net-utils to bring it up. This PR removes that assumption.

#### Testing
Modified the existing e2e test to test the case where the trunk is not up at the beginning. Test passed with the fix, failed without the fix.

Built the plugin in to agent and manually tested the following scenarios:
1. Without the fix:

* ECS optimized AMI with default configuration: awsvpc task successfully started
* ECS optimized AMI with ec2-net-utils uninstalled (before agent start): awsvpc task failed to start
* Ubuntu AMI (which doesn't have ec2-net-utils): awsvpc task failed to start
* Ubuntu AMI (manually bring up trunk interface after agent start): awsvpc task successfully started

2. With the fix:

* ECS optimized AMI with default configuration: awsvpc task successfully started
* ECS optimized AMI with ec2-net-utils uninstalled (before agent start): awsvpc task successfully started
* Ubuntu AMI: awsvpc task successfully started

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
