### PR TITLE
vpc-shared-eni: Implement L3 mode and CIDR block support on Linux

### DIFF
--- a/plugins/vpc-shared-eni/config/kubernetes.go
+++ b/plugins/vpc-shared-eni/config/kubernetes.go
@@ -114,17 +114,13 @@ func parseKubernetesArgs(netConfig *NetConfig, args *cniSkel.CmdArgs) error {
 			break
 		}
 
-		log.Info("Waiting for pod label %s.", vpcResourceNameIPAddress)
+		log.Infof("Waiting for pod label %s.", vpcResourceNameIPAddress)
 		time.Sleep(retryDelay)
 	}
 
 	if ipAddress == "" {
 		return fmt.Errorf("pod does not have label %s", vpcResourceNameIPAddress)
 	}
-
-	// Get the subnet prefix length from ENI IP address.
-	prefixLength, _ := netConfig.ENIIPAddress.Mask.Size()
-	ipAddress = fmt.Sprintf("%s/%d", ipAddress, prefixLength)
 
 	netConfig.IPAddress, err = vpc.GetIPAddressFromString(ipAddress)
 	if err != nil {

--- a/plugins/vpc-shared-eni/network/network.go
+++ b/plugins/vpc-shared-eni/network/network.go
@@ -30,6 +30,7 @@ type Builder interface {
 // Network represents a container network.
 type Network struct {
 	Name                string
+	BridgeType          string
 	BridgeNetNSPath     string
 	BridgeIndex         int
 	SharedENI           *eni.ENI

--- a/plugins/vpc-shared-eni/plugin/commands.go
+++ b/plugins/vpc-shared-eni/plugin/commands.go
@@ -56,6 +56,7 @@ func (plugin *Plugin) Add(args *cniSkel.CmdArgs) error {
 	// Find or create the container network for the shared ENI.
 	nw := network.Network{
 		Name:                netConfig.Name,
+		BridgeType:          netConfig.BridgeType,
 		BridgeNetNSPath:     netConfig.BridgeNetNSPath,
 		SharedENI:           sharedENI,
 		ENIIPAddress:        netConfig.ENIIPAddress,
@@ -148,6 +149,7 @@ func (plugin *Plugin) Del(args *cniSkel.CmdArgs) error {
 
 	nw := network.Network{
 		Name:            netConfig.Name,
+		BridgeType:      netConfig.BridgeType,
 		BridgeNetNSPath: netConfig.BridgeNetNSPath,
 		SharedENI:       sharedENI,
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change implements:
1) vpc-shared-eni L3 mode for Linux, where the container network namespaces are connected to a bridge, and the traffic between the host ENI and the bridge is achieved by IP routing.
2) vpc-shared-eni CIDR mode support where the container IP addresses can be from any CIDR range, not necessarily from one of the host ENI's subnets.
3) As a consequence of (2), the plugin can no longer know whether the container IP address is from the same subnet as the ENI. Therefore it can't append the prefix length to the IP address in Kubernetes-specific config path. The input IP address must be in CIDR format.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
