### PR TITLE
vpc-shared-eni: Set dummy link MTU for bridge to inherit

### DIFF
--- a/network/vpc/vpc.go
+++ b/network/vpc/vpc.go
@@ -17,6 +17,6 @@ const (
 	// InstanceMetadataEndpoint is EC2's instance metadata endpoint.
 	InstanceMetadataEndpoint = "169.254.169.254/32"
 
-	// JumboFrameMTU is the Jumbo Ethernet Frame Maximum Transmission Unit size in bytes.
-	JumboFrameMTU = 9000
+	// JumboFrameMTU is the VPC jumbo Ethernet frame Maximum Transmission Unit size in bytes.
+	JumboFrameMTU = 9001
 )

--- a/plugins/vpc-shared-eni/network/bridge_linux.go
+++ b/plugins/vpc-shared-eni/network/bridge_linux.go
@@ -324,18 +324,12 @@ func (nb *BridgeBuilder) createBridge(
 		}
 	}()
 
-	// Set bridge link MTU.
-	log.Infof("Setting bridge link %s MTU to %d octets.", bridgeName, vpc.JumboFrameMTU)
-	err = netlink.LinkSetMTU(bridgeLink, vpc.JumboFrameMTU)
-	if err != nil {
-		log.Errorf("Failed to set bridge link MTU: %v.", err)
-		return 0, err
-	}
-
 	// Connect a dummy link to the bridge.
+	// Bridge inherits the smallest MTU of links connected to its ports.
 	dummyName := fmt.Sprintf(dummyNameFormat, bridgeName)
 	la = netlink.NewLinkAttrs()
 	la.Name = dummyName
+	la.MTU = vpc.JumboFrameMTU
 	la.MasterIndex = bridgeLink.Attrs().Index
 	dummyLink := &netlink.Dummy{LinkAttrs: la}
 	log.Infof("Creating dummy link %+v.", dummyLink)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The Linux bridge picks the smallest MTU of the links attached to its port as its own MTU. The dummy link in vpc-shared-eni is being created without any MTUs, defaulting to 1500. The bridge then inherits this MTU of 1500 bytes because it is smaller than the MTU=9000 of other veth pairs connected to it.

This change:
1) Sets the dummy links MTU to 9001.
2) Changes the jumbo MTU from 9000 to 9001 to be consistent with VPC DHCP servers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
