### PR TITLE
netnsexec: Redirect cmd stdout/stderr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ $(BUILD_DIR)/netnsexec: $(NETNSEXEC_TOOL_SOURCE_FILES) $(COMMON_SOURCE_FILES)
 		-ldflags $(LINKER_FLAGS) \
 		-o $(BUILD_DIR)/netnsexec \
 		github.com/aws/amazon-vpc-cni-plugins/tools/netnsexec
-	@echo $(COMMON_SOURCE_FILES)
+	@echo "Built netnsexec tool."
 
 # Run all unit tests.
 .PHONY: unit-test

--- a/tools/netnsexec/main.go
+++ b/tools/netnsexec/main.go
@@ -16,21 +16,37 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"runtime"
+	"sync"
 
 	"github.com/aws/amazon-vpc-cni-plugins/network/netns"
+	"github.com/aws/amazon-vpc-cni-plugins/version"
 )
 
 // netnsexec netnsNameOrPath cmd [arg]...
 func main() {
-	var output []byte
-
+	// Parse arguments.
+	var printVersion bool
+	flag.BoolVar(&printVersion, version.Command, false, "prints version and exits")
 	flag.Parse()
+
+	if printVersion {
+		versionInfo, _ := version.String()
+		fmt.Println(versionInfo)
+		os.Exit(0)
+	}
+
 	args := flag.Args()
+	if len(args) < 2 {
+		fmt.Println("netnsexec netnsNameOrPath cmd [arg]...")
+		os.Exit(0)
+	}
+
 	nsName := args[0]
-	cmd := args[1]
+	cmdName := args[1]
 
 	// Ensure that goroutines do not change OS threads during namespace operations.
 	runtime.LockOSThread()
@@ -43,15 +59,43 @@ func main() {
 	}
 
 	err = ns.Run(func() error {
-		var err error
-		output, err = exec.Command(cmd, args[2:]...).Output()
+		cmd := exec.Command(cmdName, args[2:]...)
+
+		var errStdout, errStderr error
+		cmdStdout, _ := cmd.StdoutPipe()
+		cmdStderr, _ := cmd.StderrPipe()
+
+		err := cmd.Start()
+		if err != nil {
+			return fmt.Errorf("cmd.Start() failed: %v", err)
+		}
+
+		// Redirect cmd's stdout and stderr.
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			_, errStdout = io.Copy(os.Stdout, cmdStdout)
+			wg.Done()
+		}()
+
+		_, errStderr = io.Copy(os.Stderr, cmdStderr)
+		wg.Wait()
+
+		err = cmd.Wait()
+
+		if err != nil {
+			return fmt.Errorf("cmd.Wait() failed: %v", err)
+		}
+
+		if errStdout != nil || errStderr != nil {
+			return fmt.Errorf("failed to capture stdout: %v or stderr: %v", errStdout, errStderr)
+		}
+
 		return err
 	})
 
 	if err != nil {
-		fmt.Printf("Failed to run command %v: %v.\n", cmd, err)
+		fmt.Printf("Failed to run command %s: %v.\n", cmdName, err)
 		os.Exit(1)
 	}
-
-	fmt.Printf("%v", string(output))
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Redirect child cmd process stdout/stderr to netnsexec stdout/stderr.
* Add versioning support and --version cmd option.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
