### PR TITLE
vpc-branch-eni: Make ADDs idempotent when switching from VLAN to TAP

### DIFF
--- a/network/eni/api.go
+++ b/network/eni/api.go
@@ -34,5 +34,6 @@ type API interface {
 	SetOpState(up bool) error
 	SetNetNS(ns netns.NetNS) error
 	SetMACAddress(address net.HardwareAddr) error
-	SetIPAddress(address *net.IPNet) error
+	AddIPAddress(address *net.IPNet) error
+	DeleteIPAddress(address *net.IPNet) error
 }

--- a/network/eni/eni_linux.go
+++ b/network/eni/eni_linux.go
@@ -86,17 +86,22 @@ func (eni *ENI) SetMACAddress(address net.HardwareAddr) error {
 	return nil
 }
 
-// SetIPAddress assigns the given IP address to the ENI.
-func (eni *ENI) SetIPAddress(address *net.IPNet) error {
+// AddIPAddress assigns the given IP address to the ENI.
+func (eni *ENI) AddIPAddress(address *net.IPNet) error {
 	la := netlink.NewLinkAttrs()
 	la.Index = eni.linkIndex
 	link := &netlink.Dummy{LinkAttrs: la}
 	addr := &netlink.Addr{IPNet: address}
 
-	err := netlink.AddrAdd(link, addr)
-	if err != nil {
-		return err
-	}
+	return netlink.AddrAdd(link, addr)
+}
 
-	return nil
+// DeleteIPAddress deletes the given IP address from the ENI.
+func (eni *ENI) DeleteIPAddress(address *net.IPNet) error {
+	la := netlink.NewLinkAttrs()
+	la.Index = eni.linkIndex
+	link := &netlink.Dummy{LinkAttrs: la}
+	addr := &netlink.Addr{IPNet: address}
+
+	return netlink.AddrDel(link, addr)
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Before this change, changing a branch interface's type from VLAN to TAP required first calling CNI DEL to delete the VLAN interface, and then calling CNI ADD again to create the TAP interface. This meant links, bridges, etc. had to be deleted and recreated for no reason.

After this change, there is no need to call CNI DEL. ADD command now can convert an existing VLAN interface to a TAP interface. This simplifies the orchestrator agent code as well because it doesn't need to know the differences between stages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
