### PR TITLE
aws-appmesh: Allow app ports to be optional

### DIFF
--- a/plugins/aws-appmesh/config/netconfig.go
+++ b/plugins/aws-appmesh/config/netconfig.go
@@ -129,14 +129,18 @@ func validateConfig(config netConfigJSON) error {
 	if config.IgnoredGID == "" && config.IgnoredUID == "" {
 		return fmt.Errorf("missing required parameter ignoredGID or ignoredUID")
 	}
-	if len(config.AppPorts) == 0 {
-		return fmt.Errorf("missing required parameter appPorts")
-	}
 	if config.ProxyEgressPort == "" {
 		return fmt.Errorf("missing required parameter proxyEgressPort")
 	}
-	if config.ProxyIngressPort == "" {
-		return fmt.Errorf("missing required parameter proxyIngressPort")
+
+	// AppPorts and ProxyIngressPort go in pairs,
+	// i.e. either both are set or both are not set.
+	if config.ProxyIngressPort == "" && len(config.AppPorts) > 0 {
+		return fmt.Errorf("missing parameter proxyIngressPort (required if appPorts are provided)")
+	}
+
+	if config.ProxyIngressPort != "" && len(config.AppPorts) == 0 {
+		return fmt.Errorf("missing parameter appPorts (required if proxyIngressPort is provided)")
 	}
 
 	// Validate the format of all fields.

--- a/plugins/aws-appmesh/config/netconfig_test.go
+++ b/plugins/aws-appmesh/config/netconfig_test.go
@@ -40,6 +40,10 @@ var (
 		config{
 			netConfig: `{"ignoredGID":"1337", "proxyIngressPort":"8080", "proxyEgressPort":"8000", "appPorts":["1223"]}`,
 		},
+		config{
+			// no ingress traffic, e.g. batch job.
+			netConfig: `{"ignoredGID":"1337", "proxyEgressPort":"8000"}`,
+		},
 	}
 
 	invalidConfigs = []config{
@@ -51,6 +55,12 @@ var (
 		},
 		config{
 			netConfig: `{"ignoredUID":"1337", "proxyIngressPort":"8080", "proxyEgressPort":"8000", "appPorts":["1223","2334"], "egressIgnoredPorts":["80"], "egressIgnoredIPs":["12a.22b.128.12","2001:0db8:85a3:0000:0000:8a2e:0370:7334"]}`,
+		},
+		config{
+			netConfig: `{"ignoredGID":"1337", "proxyIngressPort":"8080", "proxyEgressPort":"8000"}`,
+		},
+		config{
+			netConfig: `{"ignoredGID":"1337", "proxyEgressPort":"8000", "appPorts":["1223"]}`,
 		},
 	}
 )

--- a/plugins/aws-appmesh/e2eTests/e2e_test.go
+++ b/plugins/aws-appmesh/e2eTests/e2e_test.go
@@ -19,11 +19,14 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 
 	"github.com/aws/amazon-vpc-cni-plugins/network/netns"
+	"github.com/aws/amazon-vpc-cni-plugins/plugins/aws-appmesh/config"
 	"github.com/containernetworking/cni/pkg/invoke"
+	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/stretchr/testify/assert"
@@ -45,37 +48,64 @@ const (
 	containerID                = "contain-er"
 	ifName                     = "test"
 	nsName                     = "testNS"
-	netConf                    = `
-{
-    "prevResult": {
-        "IPs": [{"Version":"4","Address":"10.1.2.3/16"}]
-    },
-    "type":"aws-appmesh",
-    "cniVersion":"0.3.0",
-    "ignoredUID":"1337",
-    "ignoredGID":"133",
-    "proxyEgressPort":"8080",
-    "proxyIngressPort":"8000",
-    "appPorts":["5000","5001"],
-    "egressIgnoredPorts":["80","81"],
-    "egressIgnoredIPs":["192.168.100.0/22","163.107.163.107","2001:0db8:85a3:0000:0000:8a2e:0370:7334"],
-    "enableIPv6":true
-}`
-	netConfMissingParam = `
-{
-    "type":"aws-appmesh",
-    "cniVersion":"0.3.0",
-    "ignoredUID":"1337",
-    "ignoredGID":"133",
-    "proxyEgressPort":"8080",
-    "proxyIngressPort":"8000"
-}`
 )
 
-// TestAddDel tests that the plugin adds and deletes iptables rules as expected.
-func TestAddDel(t *testing.T) {
-	// Ensure that the cni plugin exists.
-	pluginPath, err := invoke.FindInPath("aws-appmesh", []string{os.Getenv("CNI_PATH")})
+type testMeta struct {
+	name     string
+	errorMsg string
+}
+
+var (
+	pluginPath string
+)
+
+// TestValid tests when network configuration is valid.
+func TestValid(t *testing.T) {
+	initTest(t)
+
+	for _, meta := range []testMeta{
+		{
+			name: "valid_ingress_egress",
+		},
+		{
+			name: "valid_without_ingress",
+		},
+	} {
+		t.Run(meta.name, func(t *testing.T) {
+			testValid(t, meta)
+		})
+	}
+}
+
+// TestInvalid tests when network configuration is invalid.
+func TestInvalid(t *testing.T) {
+	initTest(t)
+	for _, meta := range []testMeta{
+		{
+			name:     "invalid_without_app_ports",
+			errorMsg: "missing parameter appPorts (required if proxyIngressPort is provided)",
+		},
+		{
+			name:     "invalid_without_proxy_ingress_port",
+			errorMsg: "missing parameter proxyIngressPort (required if appPorts are provided)",
+		},
+		{
+			name:     "invalid_without_proxy_egress_port",
+			errorMsg: "missing required parameter proxyEgressPort",
+		},
+	} {
+		t.Run(meta.name, func(t *testing.T) {
+			testInvalid(t, meta)
+		})
+	}
+}
+
+// initTest sets up the environment for cni executable.
+func initTest(t *testing.T) {
+	// Ensure that the eni plugin exists.
+	var err error
+
+	pluginPath, err = invoke.FindInPath("aws-appmesh", []string{os.Getenv("CNI_PATH")})
 	require.NoError(t, err, "Unable to find aws-appmesh plugin in path")
 
 	// Create a directory for storing test logs.
@@ -95,6 +125,11 @@ func TestAddDel(t *testing.T) {
 			os.RemoveAll(testLogDir)
 		}
 	}(ok)
+}
+
+// testInvalid verifies that cni ADD command returns error.
+func testInvalid(t *testing.T, meta testMeta) {
+	netConfData := loadTestData(t, meta.name)
 
 	// Create a network namespace to mimic the container's network namespace.
 	targetNS, err := netns.NewNetNS(nsName)
@@ -109,15 +144,45 @@ func TestAddDel(t *testing.T) {
 		IfName:      ifName,
 		Path:        os.Getenv("CNI_PATH"),
 	}
-	netConf := []byte(fmt.Sprintf(netConf))
+
+	// Execute the "ADD" command for the plugin.
+	execInvokeArgs.Command = "ADD"
+	err = invoke.ExecPluginWithoutResult(
+		pluginPath,
+		netConfData,
+		execInvokeArgs)
+	assert.EqualError(t, err, meta.errorMsg)
+}
+
+// testValid verifies that cni ADD and DEL command succeed.
+func testValid(t *testing.T, meta testMeta) {
+	netConfData := loadTestData(t, meta.name)
+	// Create a network namespace to mimic the container's network namespace.
+	targetNS, err := netns.NewNetNS(nsName)
+	require.NoError(t, err,
+		"Unable to create the network namespace that represents the network namespace of the container")
+	defer targetNS.Close()
+
+	// Construct args to invoke the CNI plugin with.
+	execInvokeArgs := &invoke.Args{
+		ContainerID: containerID,
+		NetNS:       targetNS.GetPath(),
+		IfName:      ifName,
+		Path:        os.Getenv("CNI_PATH"),
+	}
 
 	// Execute the "ADD" command for the plugin.
 	execInvokeArgs.Command = "ADD"
 	res, err := invoke.ExecPluginWithResult(
 		pluginPath,
-		netConf,
+		netConfData,
 		execInvokeArgs)
 	require.NoError(t, err, "Unable to execute ADD command for aws-appmesh cni plugin")
+
+	netConf, err := config.New(&skel.CmdArgs{
+		StdinData: netConfData,
+	})
+	require.NoError(t, err, "Unable to create NetConfig object for provided netConf string")
 
 	// Test that the plugin passed previous CNI result unmodified.
 	res031, err := res.GetAsVersion("0.3.1")
@@ -128,7 +193,7 @@ func TestAddDel(t *testing.T) {
 
 	targetNS.Run(func() error {
 		// Validate IP rules successfully added.
-		validateIPRules(t)
+		validateIPRules(t, netConf)
 		return nil
 	})
 
@@ -136,7 +201,7 @@ func TestAddDel(t *testing.T) {
 	execInvokeArgs.Command = "DEL"
 	err = invoke.ExecPluginWithoutResult(
 		pluginPath,
-		netConf,
+		netConfData,
 		execInvokeArgs)
 	require.NoError(t, err, "Unable to execute DEL command for aws-appmesh cni plugin")
 
@@ -147,98 +212,92 @@ func TestAddDel(t *testing.T) {
 	})
 }
 
-// TestAddReturnError tests when required network configuration is missed, ADD will return error as expected.
-func TestAddReturnError(t *testing.T) {
-	// Ensure that the eni plugin exists.
-	pluginPath, err := invoke.FindInPath("aws-appmesh", []string{os.Getenv("CNI_PATH")})
-	require.NoError(t, err, "Unable to find aws-appmesh plugin in path")
-
-	// Create a directory for storing test logs.
-	testLogDir, err := ioutil.TempDir("", "aws-appmesh-cni-e2eTests-test-")
-	require.NoError(t, err, "Unable to create directory for storing test logs")
-
-	// Configure the env var to use the test logs directory.
-	os.Setenv("VPC_CNI_LOG_FILE", fmt.Sprintf("%s/aws-appmesh.log", testLogDir))
-	defer os.Unsetenv("VPC_CNI_LOG_FILE")
-
-	// Handle deletion of test logs at the end of the test execution if specified.
-	ok, err := strconv.ParseBool(getEnvOrDefault("ECS_PRESERVE_E2E_TEST_LOGS", "false"))
-	assert.NoError(t, err, "Unable to parse ECS_PRESERVE_E2E_TEST_LOGS env var")
-	defer func(preserve bool) {
-		if !t.Failed() && !preserve {
-			os.RemoveAll(testLogDir)
-		}
-	}(ok)
-
-	// Create a network namespace to mimic the container's network namespace.
-	targetNS, err := netns.NewNetNS(nsName)
-	require.NoError(t, err,
-		"Unable to create the network namespace that represents the network namespace of the container")
-	defer targetNS.Close()
-
-	// Construct args to invoke the CNI plugin with.
-	execInvokeArgs := &invoke.Args{
-		ContainerID: containerID,
-		NetNS:       targetNS.GetPath(),
-		IfName:      ifName,
-		Path:        os.Getenv("CNI_PATH"),
+// loadTestData loads test cases in json form.
+func loadTestData(t *testing.T, name string) []byte {
+	path := filepath.Join("testdata", name+".json")
+	bytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
 	}
-	netConf := []byte(fmt.Sprintf(netConfMissingParam))
-
-	// Execute the "ADD" command for the plugin.
-	execInvokeArgs.Command = "ADD"
-	err = invoke.ExecPluginWithoutResult(
-		pluginPath,
-		netConf,
-		execInvokeArgs)
-	assert.EqualError(t, err, "missing required parameter appPorts")
+	return bytes
 }
 
 // validateIPRules validates IP rules created in the target network namespace.
-func validateIPRules(t *testing.T) {
+func validateIPRules(t *testing.T, netConf *config.NetConfig) {
+
 	protocols := []iptables.Protocol{iptables.ProtocolIPv4, iptables.ProtocolIPv6}
 
 	for _, proto := range protocols {
 		iptable, err := iptables.NewWithProtocol(proto)
 		require.NoError(t, err, "Unable to initialize iptable")
 
-		exist, _ := iptable.Exists("nat", ingressChain, "-p", "tcp", "-m", "multiport", "--dports",
-			appPorts, "-j", "REDIRECT", "--to-port", proxyIngressPort)
-		require.True(t, exist, "Failed to set rules to redirect app ports to proxy")
-
-		exist, _ = iptable.Exists("nat", "PREROUTING", "-p", "tcp", "-m", "addrtype", "!",
-			"--src-type", "LOCAL", "-j", ingressChain)
-		require.True(t, exist, "Failed to set rule to jump from PREROUTING to ingress chain")
-
-		exist, _ = iptable.Exists("nat", egressChain, "-m", "owner", "--uid-owner", uid, "-j", "RETURN")
-		require.True(t, exist, "Failed to set ignoredUID")
-
-		exist, _ = iptable.Exists("nat", egressChain, "-m", "owner", "--gid-owner", gid, "-j", "RETURN")
-		require.True(t, exist, "Failed to set ignoredGID")
-
-		exist, _ = iptable.Exists("nat", egressChain, "-p", "tcp", "-m", "multiport", "--dports",
-			egressIgnoredPorts, "-j", "RETURN")
-		require.True(t, exist, "Failed to set egressIgnoredPorts")
-
-		if proto == iptables.ProtocolIPv4 {
-			exist, _ = iptable.Exists("nat", egressChain, "-p", "tcp", "-d", egressIgnoredIPv4Addresses,
-				"-j", "RETURN")
-			require.True(t, exist, "Failed to set egressIgnoredIPv4IPs")
-		} else {
-			exist, _ = iptable.Exists("nat", egressChain, "-p", "tcp", "-d", egressIgnoredIPv6Addresses,
-				"-j", "RETURN")
-			require.True(t, exist, "Failed to set egressIgnoredIPv6IPs")
-		}
-
-		exist, err = iptable.Exists("nat", egressChain, "-p", "tcp", "-j", "REDIRECT", "--to",
-			proxyEgressPort)
-		require.True(t, exist, "Failed to set rule to redirect traffic to proxyEgressPort")
-
-		exist, err = iptable.Exists("nat", "OUTPUT", "-p", "tcp", "-m", "addrtype", "!",
-			"--dst-type", "LOCAL", "-j", egressChain)
-		require.True(t, exist, "Failed to set rule to jump from OUTPUT to egress chain")
-
+		validateIngressIptableRules(t, iptable, netConf)
+		validateEgressIptableRules(t, proto, iptable, netConf)
 	}
+}
+
+// validateIngressIptableRules validates that ingress iptable rules are setup correctly.
+func validateIngressIptableRules(t *testing.T, iptable *iptables.IPTables, netConf *config.NetConfig) {
+	exist, _ := iptable.Exists("nat", ingressChain, "-p", "tcp", "-m", "multiport", "--dports",
+		appPorts, "-j", "REDIRECT", "--to-port", proxyIngressPort)
+	if netConf.ProxyIngressPort == "" {
+		require.False(t, exist, "Found unexpected rules to redirect app ports to proxy")
+	} else {
+		require.True(t, exist, "Failed to set rules to redirect app ports to proxy")
+	}
+
+	exist, _ = iptable.Exists("nat", "PREROUTING", "-p", "tcp", "-m", "addrtype", "!",
+		"--src-type", "LOCAL", "-j", ingressChain)
+	if netConf.ProxyIngressPort == "" {
+		require.False(t, exist, "Found unexpected rule to jump from PREROUTING to ingress chain")
+	} else {
+		require.True(t, exist, "Failed to set rule to jump from PREROUTING to ingress chain")
+	}
+}
+
+// validateEgressIptableRules validates that egress iptable rules are setup correctly.
+func validateEgressIptableRules(t *testing.T, proto iptables.Protocol, iptable *iptables.IPTables, netConf *config.NetConfig) {
+	var exist bool
+	var err error
+
+	exist, err = iptable.Exists("nat", egressChain, "-m", "owner", "--uid-owner", uid, "-j", "RETURN")
+	require.NoError(t, err, "Unable to check for ignoredUID")
+	require.True(t, exist, "Failed to set ignoredUID:"+uid)
+
+	exist, err = iptable.Exists("nat", egressChain, "-m", "owner", "--gid-owner", gid, "-j", "RETURN")
+	require.NoError(t, err, "Unable to check for ignoredGID")
+	require.True(t, exist, "Failed to set ignoredGID:"+gid)
+
+	exist, err = iptable.Exists("nat", egressChain, "-p", "tcp", "-m", "multiport", "--dports",
+		egressIgnoredPorts, "-j", "RETURN")
+	require.NoError(t, err, "Unable to check for egressIgnoredPorts")
+	if len(netConf.EgressIgnoredPorts) == 0 {
+		require.False(t, exist, "Found unexpected rule for egressIgnoredPorts")
+	} else {
+		require.True(t, exist, "Failed to set egressIgnoredPorts")
+	}
+
+	if proto == iptables.ProtocolIPv4 {
+		exist, _ = iptable.Exists("nat", egressChain, "-p", "tcp", "-d", egressIgnoredIPv4Addresses,
+			"-j", "RETURN")
+	} else {
+		exist, _ = iptable.Exists("nat", egressChain, "-p", "tcp", "-d", egressIgnoredIPv6Addresses,
+			"-j", "RETURN")
+	}
+
+	if len(netConf.EgressIgnoredPorts) == 0 {
+		require.False(t, exist, "Found unexpected rule for egressIgnoredIPs")
+	} else {
+		require.True(t, exist, "Failed to set egressIgnoredIPs")
+	}
+
+	exist, _ = iptable.Exists("nat", egressChain, "-p", "tcp", "-j", "REDIRECT", "--to",
+		proxyEgressPort)
+	require.True(t, exist, "Failed to set rule to redirect traffic to proxyEgressPort")
+
+	exist, _ = iptable.Exists("nat", "OUTPUT", "-p", "tcp", "-m", "addrtype", "!",
+		"--dst-type", "LOCAL", "-j", egressChain)
+	require.True(t, exist, "Failed to set rule to jump from OUTPUT to egress chain")
 }
 
 // validateIPRulesDeleted validates IP rules deleted in the target network namespace.
@@ -249,22 +308,32 @@ func validateIPRulesDeleted(t *testing.T) {
 		iptable, err := iptables.NewWithProtocol(proto)
 		require.NoError(t, err, "Unable to initialize iptable")
 
-		exist, _ := iptable.Exists("nat", ingressChain, "-p", "tcp", "-m", "multiport", "--dports",
-			appPorts, "-j", "REDIRECT", "--to-port", proxyIngressPort)
-		require.False(t, exist, "Failed to delete rules to redirect app ports to proxy")
-
-		exist, _ = iptable.Exists("nat", "PREROUTING", "-p", "tcp", "-m", "addrtype", "!",
-			"--src-type", "LOCAL", "-j", ingressChain)
-		require.False(t, exist, "Failed to delete rules to jump from PREROUTING to ingress chain")
-
 		chains, err := iptable.ListChains("nat")
+		require.NoError(t, err, "Unable to list 'nat' chains")
 
-		exist = contains(chains, ingressChain)
-		require.False(t, exist, "Failed to delete ingress chain")
-
-		exist = contains(chains, egressChain)
-		require.False(t, exist, "Failed to delete egress chain")
+		validateIngressIptableRulesDeleted(t, iptable, chains)
+		validateEgressIptableRulesDeleted(t, iptable, chains)
 	}
+}
+
+// validateIngressIptableRulesDeleted validates ingress IP rules deleted in the target network namespace.
+func validateIngressIptableRulesDeleted(t *testing.T, iptable *iptables.IPTables, chains []string) {
+	exist, _ := iptable.Exists("nat", ingressChain, "-p", "tcp", "-m", "multiport", "--dports",
+		appPorts, "-j", "REDIRECT", "--to-port", proxyIngressPort)
+	require.False(t, exist, "Failed to delete rules to redirect app ports to proxy")
+
+	exist, _ = iptable.Exists("nat", "PREROUTING", "-p", "tcp", "-m", "addrtype", "!",
+		"--src-type", "LOCAL", "-j", ingressChain)
+	require.False(t, exist, "Failed to delete rules to jump from PREROUTING to ingress chain")
+
+	exist = contains(chains, ingressChain)
+	require.False(t, exist, "Failed to delete ingress chain")
+}
+
+// validateEgressIptableRulesDeleted validates egress IP rules deleted in the target network namespace.
+func validateEgressIptableRulesDeleted(t *testing.T, iptable *iptables.IPTables, chains []string) {
+	exist := contains(chains, egressChain)
+	require.False(t, exist, "Failed to delete egress chain")
 }
 
 // contains checks whether an element exists in the slices.

--- a/plugins/aws-appmesh/e2eTests/testdata/invalid_without_app_ports.json
+++ b/plugins/aws-appmesh/e2eTests/testdata/invalid_without_app_ports.json
@@ -1,0 +1,18 @@
+{
+    "type": "aws-appmesh",
+    "cniVersion": "0.3.0",
+    "ignoredUID": "1337",
+    "ignoredGID": "133",
+    "proxyEgressPort": "8080",
+    "proxyIngressPort": "8000",
+    "egressIgnoredPorts": [
+        "80",
+        "81"
+    ],
+    "egressIgnoredIPs": [
+        "192.168.100.0/22",
+        "163.107.163.107",
+        "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+    ],
+    "enableIPv6": true
+}

--- a/plugins/aws-appmesh/e2eTests/testdata/invalid_without_proxy_egress_port.json
+++ b/plugins/aws-appmesh/e2eTests/testdata/invalid_without_proxy_egress_port.json
@@ -1,0 +1,21 @@
+{
+    "type": "aws-appmesh",
+    "cniVersion": "0.3.0",
+    "ignoredUID": "1337",
+    "ignoredGID": "133",
+    "proxyIngressPort": "8000",
+    "appPorts": [
+        "5000",
+        "5001"
+    ],
+    "egressIgnoredPorts": [
+        "80",
+        "81"
+    ],
+    "egressIgnoredIPs": [
+        "192.168.100.0/22",
+        "163.107.163.107",
+        "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+    ],
+    "enableIPv6": true
+}

--- a/plugins/aws-appmesh/e2eTests/testdata/invalid_without_proxy_ingress_port.json
+++ b/plugins/aws-appmesh/e2eTests/testdata/invalid_without_proxy_ingress_port.json
@@ -1,0 +1,21 @@
+{
+    "type": "aws-appmesh",
+    "cniVersion": "0.3.0",
+    "ignoredUID": "1337",
+    "ignoredGID": "133",
+    "proxyEgressPort": "8080",
+    "appPorts": [
+        "5000",
+        "5001"
+    ],
+    "egressIgnoredPorts": [
+        "80",
+        "81"
+    ],
+    "egressIgnoredIPs": [
+        "192.168.100.0/22",
+        "163.107.163.107",
+        "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+    ],
+    "enableIPv6": true
+}

--- a/plugins/aws-appmesh/e2eTests/testdata/valid_ingress_egress.json
+++ b/plugins/aws-appmesh/e2eTests/testdata/valid_ingress_egress.json
@@ -1,0 +1,25 @@
+{
+    "prevResult": {
+        "IPs": [{"Version":"4","Address":"10.1.2.3/16"}]
+    },
+    "type": "aws-appmesh",
+    "cniVersion": "0.3.0",
+    "ignoredUID": "1337",
+    "ignoredGID": "133",
+    "proxyEgressPort": "8080",
+    "proxyIngressPort": "8000",
+    "appPorts": [
+        "5000",
+        "5001"
+    ],
+    "egressIgnoredPorts": [
+        "80",
+        "81"
+    ],
+    "egressIgnoredIPs": [
+        "192.168.100.0/22",
+        "163.107.163.107",
+        "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+    ],
+    "enableIPv6": true
+}

--- a/plugins/aws-appmesh/e2eTests/testdata/valid_without_ingress.json
+++ b/plugins/aws-appmesh/e2eTests/testdata/valid_without_ingress.json
@@ -1,0 +1,20 @@
+{
+    "prevResult": {
+        "IPs": [{"Version":"4","Address":"10.1.2.3/16"}]
+    },
+    "type": "aws-appmesh",
+    "cniVersion": "0.3.0",
+    "ignoredUID": "1337",
+    "ignoredGID": "133",
+    "proxyEgressPort": "8080",
+    "egressIgnoredPorts": [
+        "80",
+        "81"
+    ],
+    "egressIgnoredIPs": [
+        "192.168.100.0/22",
+        "163.107.163.107",
+        "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+    ],
+    "enableIPv6": true
+}


### PR DESCRIPTION
*Description of changes:*

This is a cherry-pick of @kiranmeduri 's prior PR (#12) with incorporation of conflicting changes and minor updates on comment style.

*Testing:*

`make build e2e-test` only -- Do we have a documented way to test this in a real runtime environment?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
