### PR TITLE
CNI Plugin changes for Windows Task Networking

### DIFF
--- a/plugins/vpc-shared-eni/config/netconfig.go
+++ b/plugins/vpc-shared-eni/config/netconfig.go
@@ -40,6 +40,7 @@ type NetConfig struct {
 	GatewayIPAddress net.IP
 	InterfaceType    string
 	TapUserID        int
+	TaskENI          bool
 	Kubernetes       KubernetesConfig
 }
 
@@ -57,6 +58,7 @@ type netConfigJSON struct {
 	InterfaceType    string   `json:"interfaceType"`
 	TapUserID        string   `json:"tapUserID"`
 	ServiceCIDR      string   `json:"serviceCIDR"`
+	TaskENI          bool     `json:"taskENI"`
 }
 
 const (
@@ -107,6 +109,7 @@ func New(args *cniSkel.CmdArgs) (*NetConfig, error) {
 		BridgeType:      config.BridgeType,
 		BridgeNetNSPath: config.BridgeNetNSPath,
 		InterfaceType:   config.InterfaceType,
+		TaskENI:         config.TaskENI,
 		Kubernetes: KubernetesConfig{
 			ServiceCIDR: config.ServiceCIDR,
 		},

--- a/plugins/vpc-shared-eni/plugin/commands.go
+++ b/plugins/vpc-shared-eni/plugin/commands.go
@@ -169,5 +169,15 @@ func (plugin *Plugin) Del(args *cniSkel.CmdArgs) error {
 		log.Errorf("Failed to delete endpoint, ignoring: %v", err)
 	}
 
+	// We delete the network along with endpoint for task networking. However, on EKS, we only delete the endpoint.
+	// TaskENI is used to check if the plugin is executed for task networking.
+	if netConfig.TaskENI {
+		err = nb.DeleteNetwork(&nw)
+		if err != nil {
+			// DEL is best-effort. Log and ignore the failure.
+			log.Errorf("Failed to delete network, ignoring: %v", err)
+		}
+	}
+
 	return nil
 }

--- a/plugins/vpc-shared-eni/plugin/plugin.go
+++ b/plugins/vpc-shared-eni/plugin/plugin.go
@@ -14,6 +14,7 @@
 package plugin
 
 import (
+	"github.com/aws/amazon-vpc-cni-plugins/capabilities"
 	"github.com/aws/amazon-vpc-cni-plugins/cni"
 	"github.com/aws/amazon-vpc-cni-plugins/plugins/vpc-shared-eni/network"
 
@@ -50,6 +51,9 @@ func NewPlugin() (*Plugin, error) {
 	}
 
 	plugin.nb = &network.BridgeBuilder{}
+
+	// Capabilities for vpc-shared-eni includes awsvpc-network-mode.
+	plugin.Capability = capabilities.New(capabilities.TaskENICapability)
 
 	return plugin, nil
 }


### PR DESCRIPTION
*Issue #, if available:*
These changes are made for supporting Task Networking for Windows

*Description of changes:*
1. Addition of AWSVPC Capability for vpc-shared-eni plugin
2. Addition of a DeleteNetwork field in configuration which indicates if the network also needs to be deleted on DEL invokation
3. Addition of delete network functionality based on DeleteNetwork when DEL is invoked

Note: We delete the network when DEL is invoked for ECS tasks. However, for EKS, we only delete the endpoints.
Therefore, we have introduced a field 'TaskENI' which is used to identify ECS tasks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
