### PR TITLE
CNI plugin changes: Windows Task Networking

### DIFF
--- a/network/routeutils/routeutils.go
+++ b/network/routeutils/routeutils.go
@@ -1,0 +1,24 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package routeutils
+
+import "net"
+
+// RouteUtils is a wrapper for executing Windows networking commands
+type RouteUtils interface {
+	// AddRoute is used to add a new route entry in the routing table
+	AddRoute(*net.IP, *net.IP, *net.IP, *int) error
+	// DeleteRoute is used to delete an existing route entry from the routing table
+	DeleteRoute(*net.IP, *net.IP, *net.IP) error
+}

--- a/network/routeutils/routeutils_windows.go
+++ b/network/routeutils/routeutils_windows.go
@@ -1,0 +1,80 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package routeutils
+
+import (
+	"errors"
+	"net"
+	"os/exec"
+
+	log "github.com/cihub/seelog"
+)
+
+const (
+	routeCommand          = "route"
+	routeAddCommand       = "add"
+	routeDeleteCommand    = "delete"
+	routeCommandMask      = "mask"
+	routeCommandInterface = "if"
+)
+
+type routeUtils struct{}
+
+// New returns a new network utils
+func New() RouteUtils {
+	return &routeUtils{}
+}
+
+// AddRoute adds a route entry in the routing table
+func (utils *routeUtils) AddRoute(destination *net.IP, subnetMask *net.IP, gateway *net.IP, interfaceNum *int) error {
+	if destination == nil || subnetMask == nil || gateway == nil {
+		return errors.New("unable to delete route due to invalid arguments")
+	}
+
+	commandArgs := utils.generateCommandArgs(destination, subnetMask, gateway, interfaceNum)
+	log.Infof("Executing command: %v", commandArgs)
+
+	return exec.Command(routeAddCommand, commandArgs...).Run()
+}
+
+// DeleteRoute deletes a route entry from the routing table
+func (utils *routeUtils) DeleteRoute(destination *net.IP, subnetMask *net.IP, gateway *net.IP) error {
+	if destination == nil || subnetMask == nil {
+		return errors.New("unable to delete route due to invalid arguments")
+	}
+
+	commandArgs := utils.generateCommandArgs(destination, subnetMask, gateway, nil)
+	log.Infof("Executing command: %v", commandArgs)
+
+	return exec.Command(routeCommand, commandArgs...).Run()
+}
+
+// generateCommandArgs generates the command arguments based on the input provided
+func (utils *routeUtils) generateCommandArgs(destination *net.IP, subnetMask *net.IP, gateway *net.IP, interfaceNum *int) []string {
+	commandArgs := make([]string, 4, 6)
+
+	commandArgs[0] = routeDeleteCommand
+	commandArgs[1] = destination.String()
+	commandArgs[2] = routeCommandMask
+	commandArgs[3] = subnetMask.String()
+	if gateway != nil {
+		commandArgs = append(commandArgs, gateway.String())
+	}
+	if interfaceNum != nil {
+		commandArgs = append(commandArgs, routeCommandInterface)
+		commandArgs = append(commandArgs, string(*interfaceNum))
+	}
+
+	return commandArgs
+}

--- a/plugins/vpc-shared-eni/config/netconfig.go
+++ b/plugins/vpc-shared-eni/config/netconfig.go
@@ -40,6 +40,7 @@ type NetConfig struct {
 	GatewayIPAddress net.IP
 	InterfaceType    string
 	TapUserID        int
+	TaskENI          bool
 	Kubernetes       KubernetesConfig
 }
 
@@ -57,6 +58,7 @@ type netConfigJSON struct {
 	InterfaceType    string   `json:"interfaceType"`
 	TapUserID        string   `json:"tapUserID"`
 	ServiceCIDR      string   `json:"serviceCIDR"`
+	TaskENI          bool     `json:"taskENI"`
 }
 
 const (
@@ -107,6 +109,7 @@ func New(args *cniSkel.CmdArgs) (*NetConfig, error) {
 		BridgeType:      config.BridgeType,
 		BridgeNetNSPath: config.BridgeNetNSPath,
 		InterfaceType:   config.InterfaceType,
+		TaskENI:         config.TaskENI,
 		Kubernetes: KubernetesConfig{
 			ServiceCIDR: config.ServiceCIDR,
 		},

--- a/plugins/vpc-shared-eni/config/netconfig.go
+++ b/plugins/vpc-shared-eni/config/netconfig.go
@@ -40,25 +40,30 @@ type NetConfig struct {
 	GatewayIPAddress net.IP
 	InterfaceType    string
 	TapUserID        int
-	TaskENI          bool
+	TaskENIConfig    TaskENIConfig
 	Kubernetes       KubernetesConfig
 }
 
 // netConfigJSON defines the network configuration JSON file format for the vpc-shared-eni plugin.
 type netConfigJSON struct {
 	cniTypes.NetConf
-	ENIName          string   `json:"eniName"`
-	ENIMACAddress    string   `json:"eniMACAddress"`
-	ENIIPAddress     string   `json:"eniIPAddress"`
-	VPCCIDRs         []string `json:"vpcCIDRs"`
-	BridgeType       string   `json:"bridgeType"`
-	BridgeNetNSPath  string   `json:"bridgeNetNSPath"`
-	IPAddress        string   `json:"ipAddress"`
-	GatewayIPAddress string   `json:"gatewayIPAddress"`
-	InterfaceType    string   `json:"interfaceType"`
-	TapUserID        string   `json:"tapUserID"`
-	ServiceCIDR      string   `json:"serviceCIDR"`
-	TaskENI          bool     `json:"taskENI"`
+	ENIName          string        `json:"eniName"`
+	ENIMACAddress    string        `json:"eniMACAddress"`
+	ENIIPAddress     string        `json:"eniIPAddress"`
+	VPCCIDRs         []string      `json:"vpcCIDRs"`
+	BridgeType       string        `json:"bridgeType"`
+	BridgeNetNSPath  string        `json:"bridgeNetNSPath"`
+	IPAddress        string        `json:"ipAddress"`
+	GatewayIPAddress string        `json:"gatewayIPAddress"`
+	InterfaceType    string        `json:"interfaceType"`
+	TapUserID        string        `json:"tapUserID"`
+	ServiceCIDR      string        `json:"serviceCIDR"`
+	TaskENIConfig    TaskENIConfig `json:"taskENIConfig"`
+}
+
+// TaskENIConfig defines the Task Networking specific data required by the plugin
+type TaskENIConfig struct {
+	PauseContainer bool `json:"pauseContainer"`
 }
 
 const (
@@ -109,7 +114,7 @@ func New(args *cniSkel.CmdArgs) (*NetConfig, error) {
 		BridgeType:      config.BridgeType,
 		BridgeNetNSPath: config.BridgeNetNSPath,
 		InterfaceType:   config.InterfaceType,
-		TaskENI:         config.TaskENI,
+		TaskENIConfig:   config.TaskENIConfig,
 		Kubernetes: KubernetesConfig{
 			ServiceCIDR: config.ServiceCIDR,
 		},

--- a/plugins/vpc-shared-eni/network/network.go
+++ b/plugins/vpc-shared-eni/network/network.go
@@ -16,6 +16,8 @@ package network
 import (
 	"net"
 
+	"github.com/aws/amazon-vpc-cni-plugins/plugins/vpc-shared-eni/config"
+
 	"github.com/aws/amazon-vpc-cni-plugins/network/eni"
 )
 
@@ -40,6 +42,7 @@ type Network struct {
 	DNSServers          []string
 	DNSSuffixSearchList []string
 	ServiceCIDR         string
+	TaskENIConfig       config.TaskENIConfig
 }
 
 // Endpoint represents a container network interface.

--- a/plugins/vpc-shared-eni/plugin/commands.go
+++ b/plugins/vpc-shared-eni/plugin/commands.go
@@ -65,6 +65,7 @@ func (plugin *Plugin) Add(args *cniSkel.CmdArgs) error {
 		DNSServers:          netConfig.DNS.Nameservers,
 		DNSSuffixSearchList: netConfig.DNS.Search,
 		ServiceCIDR:         netConfig.Kubernetes.ServiceCIDR,
+		TaskENIConfig:       netConfig.TaskENIConfig,
 	}
 
 	err = nb.FindOrCreateNetwork(&nw)
@@ -170,8 +171,8 @@ func (plugin *Plugin) Del(args *cniSkel.CmdArgs) error {
 	}
 
 	// We delete the network along with endpoint for task networking. However, on EKS, we only delete the endpoint.
-	// TaskENI is used to check if the plugin is executed for task networking.
-	if netConfig.TaskENI {
+	// TaskENIConfig is used to check if the plugin is executed for task networking.
+	if netConfig.TaskENIConfig.PauseContainer {
 		err = nb.DeleteNetwork(&nw)
 		if err != nil {
 			// DEL is best-effort. Log and ignore the failure.

--- a/plugins/vpc-shared-eni/plugin/commands.go
+++ b/plugins/vpc-shared-eni/plugin/commands.go
@@ -169,5 +169,15 @@ func (plugin *Plugin) Del(args *cniSkel.CmdArgs) error {
 		log.Errorf("Failed to delete endpoint, ignoring: %v", err)
 	}
 
+	// We delete the network along with endpoint for task networking. However, on EKS, we only delete the endpoint.
+	// TaskENI is used to check if the plugin is executed for task networking.
+	if netConfig.TaskENI {
+		err = nb.DeleteNetwork(&nw)
+		if err != nil {
+			// DEL is best-effort. Log and ignore the failure.
+			log.Errorf("Failed to delete network, ignoring: %v", err)
+		}
+	}
+
 	return nil
 }

--- a/plugins/vpc-shared-eni/plugin/plugin.go
+++ b/plugins/vpc-shared-eni/plugin/plugin.go
@@ -14,6 +14,7 @@
 package plugin
 
 import (
+	"github.com/aws/amazon-vpc-cni-plugins/capabilities"
 	"github.com/aws/amazon-vpc-cni-plugins/cni"
 	"github.com/aws/amazon-vpc-cni-plugins/plugins/vpc-shared-eni/network"
 
@@ -50,6 +51,9 @@ func NewPlugin() (*Plugin, error) {
 	}
 
 	plugin.nb = &network.BridgeBuilder{}
+
+	// Capabilities for vpc-shared-eni includes awsvpc-network-mode.
+	plugin.Capability = capabilities.New(capabilities.TaskENICapability)
 
 	return plugin, nil
 }


### PR DESCRIPTION
***Issue #, if available:***
Issue 1: Support for Windows task networking

Issue 2:
On Windows, whenever an ENI is attached to a Windows instance, a stale route entry is added in the default network namespace.
Due to this entry, we cannot access the task using the task ENI’s IP from the same instance. This also means that the task cannot be accessed from any non-awsvpc mode tasks present on the same instance.
This entry needs to be deleted from the default network namespace.
 
**Steps to replicate the issue:**
1. Launch an EC2 Windows instance
2. Create a new network interface from EC2 console
3. Connect this network interface to the Windows instance

We will find a stale route entry as below:
| ifIndex  | DestinationPrefix | NextHop |
| ------------- | ------------- | ------------- |
| ifIndex of the ENI   | ENI IP Address/32  | 0.0.0.0 |            

***Description of changes:***
1. Addition of AWSVPC Capability for vpc-shared-eni plugin
2. When vpc-shared-eni CNI plugin is invoked for task networking then on invocation of DEL, we will delete l2bridge network created for Task ENI
3. The changes are introduced to delete the stale route entry of the task ENI from the host compartment's routing table.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
