### PR TITLE
vpc-shared-eni: Remove call to get Pod from API Server in DEL command

### DIFF
--- a/plugins/vpc-shared-eni/config/kubernetes.go
+++ b/plugins/vpc-shared-eni/config/kubernetes.go
@@ -49,8 +49,8 @@ var (
 	retrievePodConfigHandler func(netConfig *NetConfig) error
 )
 
-// parseKubernetesArgs parses Kubernetes-specific CNI arguments.
-func parseKubernetesArgs(netConfig *NetConfig, args *cniSkel.CmdArgs) error {
+// ParseKubernetesArgs parses Kubernetes-specific CNI arguments.
+func ParseKubernetesArgs(netConfig *NetConfig, args *cniSkel.CmdArgs) error {
 	if args == nil || args.Args == "" {
 		return nil
 	}

--- a/plugins/vpc-shared-eni/config/netconfig.go
+++ b/plugins/vpc-shared-eni/config/netconfig.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-	"strings"
 
 	"github.com/aws/amazon-vpc-cni-plugins/network/vpc"
 
@@ -170,14 +169,6 @@ func New(args *cniSkel.CmdArgs) (*NetConfig, error) {
 		netConfig.TapUserID, err = strconv.Atoi(config.TapUserID)
 		if err != nil {
 			return nil, fmt.Errorf("invalid TapUserID %s", config.TapUserID)
-		}
-	}
-
-	// Parse orchestrator-specific configuration.
-	if strings.Contains(args.Args, "K8S") {
-		err = parseKubernetesArgs(&netConfig, args)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse Kubernetes args: %v", err)
 		}
 	}
 

--- a/plugins/vpc-shared-eni/plugin/commands.go
+++ b/plugins/vpc-shared-eni/plugin/commands.go
@@ -14,6 +14,9 @@
 package plugin
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/aws/amazon-vpc-cni-plugins/network/eni"
 	"github.com/aws/amazon-vpc-cni-plugins/plugins/vpc-shared-eni/config"
 	"github.com/aws/amazon-vpc-cni-plugins/plugins/vpc-shared-eni/network"
@@ -31,6 +34,17 @@ func (plugin *Plugin) Add(args *cniSkel.CmdArgs) error {
 	if err != nil {
 		log.Errorf("Failed to parse netconfig from args: %v.", err)
 		return err
+	}
+
+	// Parse orchestrator-specific configuration.
+	if strings.Contains(args.Args, "K8S") {
+		err = config.ParseKubernetesArgs(netConfig, args)
+		if err != nil {
+			err := fmt.Errorf("failed to find the IP Address from Pod Object %s/%s: %v",
+			netConfig.Kubernetes.Namespace, netConfig.Kubernetes.PodName, err)
+			log.Error(err)
+			return err
+		}
 	}
 
 	log.Infof("Executing ADD with netconfig: %+v ContainerID:%v Netns:%v IfName:%v Args:%v.",
@@ -160,7 +174,6 @@ func (plugin *Plugin) Del(args *cniSkel.CmdArgs) error {
 		IfName:      args.IfName,
 		IfType:      netConfig.InterfaceType,
 		TapUserID:   netConfig.TapUserID,
-		IPAddress:   netConfig.IPAddress,
 	}
 
 	err = nb.DeleteEndpoint(&nw, &ep)


### PR DESCRIPTION
*Issue #42:*
- Containers and HNS Endpoints are being leaked when the pod object is already deleted from etcd and we are trying to get it using kube client in the delete request which results in the delete request to fail.  

*Description of changes:*
We don't need to query the API Server on DEL command as we get the Endpoint details using the container ID. We only query the API Server on ADD command to get the IP Address from the Pod's Annotation.

Resolves: #42 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
