### PR TITLE
Revert "vpc-shared-eni: Remove call to get Pod from API Server in DEL command"

### DIFF
--- a/plugins/vpc-shared-eni/config/kubernetes.go
+++ b/plugins/vpc-shared-eni/config/kubernetes.go
@@ -49,8 +49,8 @@ var (
 	retrievePodConfigHandler func(netConfig *NetConfig) error
 )
 
-// ParseKubernetesArgs parses Kubernetes-specific CNI arguments.
-func ParseKubernetesArgs(netConfig *NetConfig, args *cniSkel.CmdArgs) error {
+// parseKubernetesArgs parses Kubernetes-specific CNI arguments.
+func parseKubernetesArgs(netConfig *NetConfig, args *cniSkel.CmdArgs) error {
 	if args == nil || args.Args == "" {
 		return nil
 	}

--- a/plugins/vpc-shared-eni/config/netconfig.go
+++ b/plugins/vpc-shared-eni/config/netconfig.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 
 	"github.com/aws/amazon-vpc-cni-plugins/network/vpc"
 
@@ -169,6 +170,14 @@ func New(args *cniSkel.CmdArgs) (*NetConfig, error) {
 		netConfig.TapUserID, err = strconv.Atoi(config.TapUserID)
 		if err != nil {
 			return nil, fmt.Errorf("invalid TapUserID %s", config.TapUserID)
+		}
+	}
+
+	// Parse orchestrator-specific configuration.
+	if strings.Contains(args.Args, "K8S") {
+		err = parseKubernetesArgs(&netConfig, args)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse Kubernetes args: %v", err)
 		}
 	}
 

--- a/plugins/vpc-shared-eni/plugin/commands.go
+++ b/plugins/vpc-shared-eni/plugin/commands.go
@@ -14,9 +14,6 @@
 package plugin
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/aws/amazon-vpc-cni-plugins/network/eni"
 	"github.com/aws/amazon-vpc-cni-plugins/plugins/vpc-shared-eni/config"
 	"github.com/aws/amazon-vpc-cni-plugins/plugins/vpc-shared-eni/network"
@@ -34,17 +31,6 @@ func (plugin *Plugin) Add(args *cniSkel.CmdArgs) error {
 	if err != nil {
 		log.Errorf("Failed to parse netconfig from args: %v.", err)
 		return err
-	}
-
-	// Parse orchestrator-specific configuration.
-	if strings.Contains(args.Args, "K8S") {
-		err = config.ParseKubernetesArgs(netConfig, args)
-		if err != nil {
-			err := fmt.Errorf("failed to find the IP Address from Pod Object %s/%s: %v",
-			netConfig.Kubernetes.Namespace, netConfig.Kubernetes.PodName, err)
-			log.Error(err)
-			return err
-		}
 	}
 
 	log.Infof("Executing ADD with netconfig: %+v ContainerID:%v Netns:%v IfName:%v Args:%v.",
@@ -174,6 +160,7 @@ func (plugin *Plugin) Del(args *cniSkel.CmdArgs) error {
 		IfName:      args.IfName,
 		IfType:      netConfig.InterfaceType,
 		TapUserID:   netConfig.TapUserID,
+		IPAddress:   netConfig.IPAddress,
 	}
 
 	err = nb.DeleteEndpoint(&nw, &ep)


### PR DESCRIPTION
Reverts aws/amazon-vpc-cni-plugins#44

Will do a follow up PR with the following 
- Pass the flag to config.New if it's a delete request and if true don't parse k8s Arguments and make K8s API Call.