### PR TITLE
vpc-shared-eni: Remove call to get Pod from API Server in DEL command

### DIFF
--- a/plugins/vpc-shared-eni/config/kubernetes.go
+++ b/plugins/vpc-shared-eni/config/kubernetes.go
@@ -50,8 +50,11 @@ var (
 )
 
 // parseKubernetesArgs parses Kubernetes-specific CNI arguments.
-func parseKubernetesArgs(netConfig *NetConfig, args *cniSkel.CmdArgs) error {
-	if args == nil || args.Args == "" {
+func parseKubernetesArgs(netConfig *NetConfig, args *cniSkel.CmdArgs, isAddCmd bool) error {
+	// The only additional information we need to query from API server is the pod IP address,
+	// which is required only for ADD commands. Also the API server may have deleted the pod
+	// object already in the DEL path.
+	if !isAddCmd ||  args == nil || args.Args == "" {
 		return nil
 	}
 

--- a/plugins/vpc-shared-eni/config/kubernetes.go
+++ b/plugins/vpc-shared-eni/config/kubernetes.go
@@ -51,10 +51,7 @@ var (
 
 // parseKubernetesArgs parses Kubernetes-specific CNI arguments.
 func parseKubernetesArgs(netConfig *NetConfig, args *cniSkel.CmdArgs, isAddCmd bool) error {
-	// The only additional information we need to query from API server is the pod IP address,
-	// which is required only for ADD commands. Also the API server may have deleted the pod
-	// object already in the DEL path.
-	if !isAddCmd ||  args == nil || args.Args == "" {
+	if args == nil || args.Args == "" {
 		return nil
 	}
 
@@ -71,6 +68,13 @@ func parseKubernetesArgs(netConfig *NetConfig, args *cniSkel.CmdArgs, isAddCmd b
 	kc.Namespace = string(ka.K8S_POD_NAMESPACE)
 	kc.PodName = string(ka.K8S_POD_NAME)
 	kc.PodInfraContainerID = string(ka.K8S_POD_INFRA_CONTAINER_ID)
+
+	// The only additional information we need to query from API server is the pod IP address,
+	// which is required only for ADD commands. Also the API server may have deleted the pod
+	// object already in the DEL path.
+	if !isAddCmd {
+		return nil
+	}
 
 	if kc.Namespace == "" || kc.PodName == "" {
 		return fmt.Errorf("missing required args %v", kc)

--- a/plugins/vpc-shared-eni/config/netconfig.go
+++ b/plugins/vpc-shared-eni/config/netconfig.go
@@ -74,7 +74,7 @@ const (
 )
 
 // New creates a new NetConfig object by parsing the given CNI arguments.
-func New(args *cniSkel.CmdArgs) (*NetConfig, error) {
+func New(args *cniSkel.CmdArgs, isAddCmd bool) (*NetConfig, error) {
 	// Parse network configuration.
 	var config netConfigJSON
 	err := json.Unmarshal(args.StdinData, &config)
@@ -175,7 +175,7 @@ func New(args *cniSkel.CmdArgs) (*NetConfig, error) {
 
 	// Parse orchestrator-specific configuration.
 	if strings.Contains(args.Args, "K8S") {
-		err = parseKubernetesArgs(&netConfig, args)
+		err = parseKubernetesArgs(&netConfig, args, isAddCmd)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse Kubernetes args: %v", err)
 		}

--- a/plugins/vpc-shared-eni/plugin/commands.go
+++ b/plugins/vpc-shared-eni/plugin/commands.go
@@ -27,7 +27,7 @@ import (
 // Add is the CNI ADD command handler.
 func (plugin *Plugin) Add(args *cniSkel.CmdArgs) error {
 	// Parse network configuration.
-	netConfig, err := config.New(args)
+	netConfig, err := config.New(args, true)
 	if err != nil {
 		log.Errorf("Failed to parse netconfig from args: %v.", err)
 		return err
@@ -121,7 +121,7 @@ func (plugin *Plugin) Add(args *cniSkel.CmdArgs) error {
 // Del is the CNI DEL command handler.
 func (plugin *Plugin) Del(args *cniSkel.CmdArgs) error {
 	// Parse network configuration.
-	netConfig, err := config.New(args)
+	netConfig, err := config.New(args, false)
 	if err != nil {
 		log.Errorf("Failed to parse netconfig from args: %v.", err)
 		return err


### PR DESCRIPTION
As suggested by @ofiliz, refactoring the code in a cleaner way with additional comments explaining the reason for the change.

*Description of changes:*

We don't need to query the API Server on DEL command as we get the
Endpoint details using the container ID. We only query the API Server
on ADD command to get the IP Address from the Pod's Annotation.

Note: IP Address information will be required for EKS Linux node which
are not supported yet.

Resolves: #42




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
