### PR TITLE
vpc-shared-eni: Delete HNS Endpoint if HotDetachEndpoint fails

### DIFF
--- a/plugins/vpc-shared-eni/network/bridge_windows.go
+++ b/plugins/vpc-shared-eni/network/bridge_windows.go
@@ -284,7 +284,7 @@ func (nb *BridgeBuilder) DeleteEndpoint(nw *Network, ep *Endpoint) error {
 	// Detach the HNS endpoint from the container's network namespace.
 	log.Infof("Detaching HNS endpoint %s from container %s netns.", hnsEndpoint.Id, ep.ContainerID)
 	err = hcsshim.HotDetachEndpoint(ep.ContainerID, hnsEndpoint.Id)
-	if err != nil {
+	if err != nil && err != hcsshim.ErrComputeSystemDoesNotExist {
 		return err
 	}
 


### PR DESCRIPTION
*Description of changes:*

In DEL Command, when the HotDetachEndpoint API fails if the container no longer exists, we simply return the error which would lead to a leaked HNSEndpoint. Fixing it by logging the error and trying to delete the HNSEndpoint before returning the error.

*Testing*
Reproduced the scenario and from the logs below we can see that endpoint 5416E24E-09B6-4D47-B536-2B650919D8E9 is cleaned up in case we encounter an error of type ```ErrComputeSystemDoesNotExist``` on calling the ```HotDetachEndpoint```.

```
2020-08-10T07:41:36Z [ERROR] failed to detach endpoint 5416E24E-09B6-4D47-B536-2B650919D8E9 from container e86c2ef847de726870492686bc418f81fa17951e29a886dc8212676774e44a9f as it's no longer running: A virtual machine or container with the specified identifier does not exist.
2020-08-10T07:41:36Z [INFO] Deleting HNS endpoint name: cid-e86c2ef847de726870492686bc418f81fa17951e29a886dc8212676774e44a9f ID: 5416E24E-09B6-4D47-B536-2B650919D8E9
```

[vpc-shared-eni.log](https://github.com/aws/amazon-vpc-cni-plugins/files/5049563/vpc-shared-eni.log)

Resolves: #47 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
