### PR TITLE
Update `vpc-shared-eni` plugin to work with namespaces

### DIFF
--- a/plugins/vpc-shared-eni/config/netconfig.go
+++ b/plugins/vpc-shared-eni/config/netconfig.go
@@ -113,7 +113,7 @@ func New(args *cniSkel.CmdArgs, isAddCmd bool) (*NetConfig, error) {
 		BridgeType:      config.BridgeType,
 		BridgeNetNSPath: config.BridgeNetNSPath,
 		InterfaceType:   config.InterfaceType,
-		TaskENIConfig: config.TaskENIConfig,
+		TaskENIConfig:   config.TaskENIConfig,
 		Kubernetes: KubernetesConfig{
 			ServiceCIDR: config.ServiceCIDR,
 		},

--- a/plugins/vpc-shared-eni/config/netconfig.go
+++ b/plugins/vpc-shared-eni/config/netconfig.go
@@ -40,23 +40,29 @@ type NetConfig struct {
 	GatewayIPAddress net.IP
 	InterfaceType    string
 	TapUserID        int
+	TaskENIConfig    TaskENIConfig
 	Kubernetes       KubernetesConfig
 }
 
 // netConfigJSON defines the network configuration JSON file format for the vpc-shared-eni plugin.
 type netConfigJSON struct {
 	cniTypes.NetConf
-	ENIName          string   `json:"eniName"`
-	ENIMACAddress    string   `json:"eniMACAddress"`
-	ENIIPAddress     string   `json:"eniIPAddress"`
-	VPCCIDRs         []string `json:"vpcCIDRs"`
-	BridgeType       string   `json:"bridgeType"`
-	BridgeNetNSPath  string   `json:"bridgeNetNSPath"`
-	IPAddress        string   `json:"ipAddress"`
-	GatewayIPAddress string   `json:"gatewayIPAddress"`
-	InterfaceType    string   `json:"interfaceType"`
-	TapUserID        string   `json:"tapUserID"`
-	ServiceCIDR      string   `json:"serviceCIDR"`
+	ENIName          string        `json:"eniName"`
+	ENIMACAddress    string        `json:"eniMACAddress"`
+	ENIIPAddress     string        `json:"eniIPAddress"`
+	VPCCIDRs         []string      `json:"vpcCIDRs"`
+	BridgeType       string        `json:"bridgeType"`
+	BridgeNetNSPath  string        `json:"bridgeNetNSPath"`
+	IPAddress        string        `json:"ipAddress"`
+	GatewayIPAddress string        `json:"gatewayIPAddress"`
+	InterfaceType    string        `json:"interfaceType"`
+	TapUserID        string        `json:"tapUserID"`
+	ServiceCIDR      string        `json:"serviceCIDR"`
+	TaskENIConfig    TaskENIConfig `json:"taskENIConfig"`
+}
+
+type TaskENIConfig struct {
+	NoInfra bool `json:"noInfra"`
 }
 
 const (
@@ -107,6 +113,7 @@ func New(args *cniSkel.CmdArgs, isAddCmd bool) (*NetConfig, error) {
 		BridgeType:      config.BridgeType,
 		BridgeNetNSPath: config.BridgeNetNSPath,
 		InterfaceType:   config.InterfaceType,
+		TaskENIConfig: config.TaskENIConfig,
 		Kubernetes: KubernetesConfig{
 			ServiceCIDR: config.ServiceCIDR,
 		},

--- a/plugins/vpc-shared-eni/network/bridge_linux.go
+++ b/plugins/vpc-shared-eni/network/bridge_linux.go
@@ -31,6 +31,9 @@ import (
 )
 
 const (
+	// LogFilePath is the path to the plugin's log file.
+	LogFilePath = "/var/log/vpc-shared-eni.log"
+
 	// bridgeNameFormat is the format used for generating bridge names (e.g. "vpcbr1").
 	bridgeNameFormat = "%sbr%d"
 

--- a/plugins/vpc-shared-eni/network/bridge_windows.go
+++ b/plugins/vpc-shared-eni/network/bridge_windows.go
@@ -17,13 +17,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/aws/amazon-vpc-cni-plugins/network/vpc"
 
 	"github.com/Microsoft/hcsshim"
 	"github.com/Microsoft/hcsshim/hcn"
-
 	log "github.com/cihub/seelog"
 )
 
@@ -41,6 +42,11 @@ const (
 var (
 	// hnsMinVersion is the minimum version of HNS supported by this plugin.
 	hnsMinVersion = hcsshim.HNSVersion1803
+)
+
+var (
+	// LogFilePath is the path to the plugin's log file.
+	LogFilePath = filepath.Join(os.Getenv("ProgramFiles"), "Amazon", "cni", "log", "vpc-shared-eni.log")
 )
 
 // hnsRoutePolicy is an HNS route policy.
@@ -310,7 +316,7 @@ func (nb *BridgeBuilder) findOrCreateEndpointNS(nw *Network, ep *Endpoint) error
 	err = nb.addEndpointPolicy(
 		hnsEndpoint,
 		hnsRoutePolicy{
-			Policy:            hcsshim.Policy{Type: hcsshim.OutboundNat},
+			Policy: hcsshim.Policy{Type: hcsshim.OutboundNat},
 		})
 	if err != nil {
 		log.Errorf("Failed to add OutboundNat policy: %v.", err)

--- a/plugins/vpc-shared-eni/network/bridge_windows.go
+++ b/plugins/vpc-shared-eni/network/bridge_windows.go
@@ -407,7 +407,6 @@ func (nb *BridgeBuilder) deleteEndpointNS(nw *Network, ep *Endpoint) error {
 
 	// Delete the HNS endpoint.
 	log.Infof("Deleting HNS endpoint name: %s ID: %s.", endpointName, hnsEndpoint.Id)
-	//_, err = hcsshim.HNSEndpointRequest("DELETE", hnsEndpoint.Id, "")
 	_, err = hnsEndpoint.Delete()
 	if err != nil {
 		log.Errorf("Failed to delete HNS endpoint: %v.", err)

--- a/plugins/vpc-shared-eni/network/network.go
+++ b/plugins/vpc-shared-eni/network/network.go
@@ -17,6 +17,7 @@ import (
 	"net"
 
 	"github.com/aws/amazon-vpc-cni-plugins/network/eni"
+	"github.com/aws/amazon-vpc-cni-plugins/plugins/vpc-shared-eni/config"
 )
 
 // Builder knows how to build container networks and connect container network interfaces.
@@ -40,6 +41,7 @@ type Network struct {
 	DNSServers          []string
 	DNSSuffixSearchList []string
 	ServiceCIDR         string
+	TaskENIConfig       config.TaskENIConfig
 }
 
 // Endpoint represents a container network interface.

--- a/plugins/vpc-shared-eni/plugin/commands.go
+++ b/plugins/vpc-shared-eni/plugin/commands.go
@@ -65,6 +65,7 @@ func (plugin *Plugin) Add(args *cniSkel.CmdArgs) error {
 		DNSServers:          netConfig.DNS.Nameservers,
 		DNSSuffixSearchList: netConfig.DNS.Search,
 		ServiceCIDR:         netConfig.Kubernetes.ServiceCIDR,
+		TaskENIConfig:       netConfig.TaskENIConfig,
 	}
 
 	err = nb.FindOrCreateNetwork(&nw)

--- a/plugins/vpc-shared-eni/plugin/commands.go
+++ b/plugins/vpc-shared-eni/plugin/commands.go
@@ -153,6 +153,7 @@ func (plugin *Plugin) Del(args *cniSkel.CmdArgs) error {
 		BridgeType:      netConfig.BridgeType,
 		BridgeNetNSPath: netConfig.BridgeNetNSPath,
 		SharedENI:       sharedENI,
+		TaskENIConfig:   netConfig.TaskENIConfig,
 	}
 
 	ep := network.Endpoint{

--- a/plugins/vpc-shared-eni/plugin/commands.go
+++ b/plugins/vpc-shared-eni/plugin/commands.go
@@ -167,7 +167,15 @@ func (plugin *Plugin) Del(args *cniSkel.CmdArgs) error {
 	err = nb.DeleteEndpoint(&nw, &ep)
 	if err != nil {
 		// DEL is best-effort. Log and ignore the failure.
-		log.Errorf("Failed to delete endpoint, ignoring: %v", err)
+		log.Errorf("Failed to delete endpoint, ignoring: %v.", err)
+	}
+
+	if netConfig.TaskENIConfig.NoInfra {
+		err = nb.DeleteNetwork(&nw)
+		if err != nil {
+			log.Errorf("Failed to delete network: %v.", err)
+			return err
+		}
 	}
 
 	return nil

--- a/plugins/vpc-shared-eni/plugin/plugin.go
+++ b/plugins/vpc-shared-eni/plugin/plugin.go
@@ -23,9 +23,6 @@ import (
 const (
 	// pluginName is the name of the plugin as specified in CNI config files.
 	pluginName = "vpc-shared-eni"
-
-	// logFilePath is the path to the plugin's log file.
-	logFilePath = "C:/cni/vpc-shared-eni.log"
 )
 
 var (
@@ -44,7 +41,7 @@ func NewPlugin() (*Plugin, error) {
 	var err error
 	plugin := &Plugin{}
 
-	plugin.Plugin, err = cni.NewPlugin(pluginName, specVersions, logFilePath, plugin)
+	plugin.Plugin, err = cni.NewPlugin(pluginName, specVersions, network.LogFilePath, plugin)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/vpc-shared-eni/plugin/plugin.go
+++ b/plugins/vpc-shared-eni/plugin/plugin.go
@@ -25,7 +25,7 @@ const (
 	pluginName = "vpc-shared-eni"
 
 	// logFilePath is the path to the plugin's log file.
-	logFilePath = "/var/log/vpc-shared-eni.log"
+	logFilePath = "C:/cni/vpc-shared-eni.log"
 )
 
 var (


### PR DESCRIPTION
Update `vpc-shared-eni` plugin to work with `namespaces` and `containerd`. 

**Description**
This PR will enable task(container) connectivity (ingress/engress) using a network interface's primary IP address. This will be followed up with another PR to enable features dependent on other components like `amazon-ecs-agent`. 

The incoming changes will not disrupt any of the existing `EKS Windows` workflows. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
