### PR TITLE
Adding ipv6 support for vpc shared eni

### DIFF
--- a/network/ipcfg/ip.go
+++ b/network/ipcfg/ip.go
@@ -23,6 +23,10 @@ import (
 const (
 	ipv4Forwarding = "/proc/sys/net/ipv4/conf/%s/forwarding"
 	ipv4ProxyARP   = "/proc/sys/net/ipv4/conf/%s/proxy_arp"
+
+	ipv6Forwarding = "/proc/sys/net/ipv6/conf/%s/forwarding"
+	ipv6AcceptRA   = "/proc/sys/net/ipv6/conf/%s/accept_ra"
+	ipv6AcceptDAD  = "/proc/sys/net/ipv6/conf/%s/accept_dad"
 )
 
 // SetIPv4Forwarding sets the IPv4 forwarding property of an interface to the given value.
@@ -33,6 +37,21 @@ func SetIPv4Forwarding(ifName string, value int) error {
 // SetIPv4ProxyARP sets the IPv4 proxy ARP property of an interface to the given value.
 func SetIPv4ProxyARP(ifName string, value int) error {
 	return set(fmt.Sprintf(ipv4ProxyARP, ifName), value)
+}
+
+// SetIPv6Forwarding sets the IPv6 forwarding property of an interface to the given value.
+func SetIPv6Forwarding(ifName string, value int) error {
+	return set(fmt.Sprintf(ipv6Forwarding, ifName), value)
+}
+
+// SetIPv6AcceptRA sets the IPv6 accept RA property of an interface to the given value.
+func SetIPv6AcceptRA(ifName string, value int) error {
+	return set(fmt.Sprintf(ipv6AcceptRA, ifName), value)
+}
+
+// SetIPv6AcceptDAD sets the IPv6 accept DAD property of an interface to the given value.
+func SetIPv6AcceptDAD(ifName string, value int) error {
+	return set(fmt.Sprintf(ipv6AcceptDAD, ifName), value)
 }
 
 // Set sets a system variable to the given value.

--- a/network/vpc/address.go
+++ b/network/vpc/address.go
@@ -43,3 +43,23 @@ func CompareMACAddress(addr1, addr2 net.HardwareAddr) bool {
 
 	return true
 }
+
+// ListContainsIPv4Address returns whether the given IP address list contains an IPv4 address.
+func ListContainsIPv4Address(ipAddresses []net.IPNet) bool {
+	for _, addr := range ipAddresses {
+		if addr.IP.To4() != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// ListContainsIPv6Address returns whether the given IP address list contains an IPv6 address.
+func ListContainsIPv6Address(ipAddresses []net.IPNet) bool {
+	for _, addr := range ipAddresses {
+		if addr.IP.To4() == nil {
+			return true
+		}
+	}
+	return false
+}

--- a/plugins/vpc-shared-eni/config/kubeapi.go
+++ b/plugins/vpc-shared-eni/config/kubeapi.go
@@ -74,10 +74,11 @@ func retrievePodConfig(netConfig *NetConfig) error {
 		return fmt.Errorf("pod does not have label %s", vpcResourceNameIPv4Address)
 	}
 
-	netConfig.IPAddress, err = vpc.GetIPAddressFromString(ipAddress)
+	ipAddr, err := vpc.GetIPAddressFromString(ipAddress)
 	if err != nil {
 		return fmt.Errorf("invalid IPAddress %s from pod label", ipAddress)
 	}
+	netConfig.IPAddresses = append(netConfig.IPAddresses, *ipAddr)
 
 	return nil
 }

--- a/plugins/vpc-shared-eni/config/kubernetes.go
+++ b/plugins/vpc-shared-eni/config/kubernetes.go
@@ -86,7 +86,7 @@ func parseKubernetesArgs(netConfig *NetConfig, args *cniSkel.CmdArgs, isAddCmd b
 	}
 
 	// Retrieve any missing information not available in netconfig.
-	if retrievePodConfigHandler != nil && netConfig.IPAddress == nil {
+	if retrievePodConfigHandler != nil && len(netConfig.IPAddresses) == 0 {
 		err = retrievePodConfigHandler(netConfig)
 	}
 

--- a/plugins/vpc-shared-eni/config/netconfig.go
+++ b/plugins/vpc-shared-eni/config/netconfig.go
@@ -32,11 +32,11 @@ type NetConfig struct {
 	cniTypes.NetConf
 	ENIName          string
 	ENIMACAddress    net.HardwareAddr
-	ENIIPAddress     *net.IPNet
+	ENIIPAddresses   []net.IPNet
 	VPCCIDRs         []net.IPNet
 	BridgeType       string
 	BridgeNetNSPath  string
-	IPAddress        *net.IPNet
+	IPAddresses      []net.IPNet
 	GatewayIPAddress net.IP
 	InterfaceType    string
 	TapUserID        int
@@ -48,11 +48,11 @@ type netConfigJSON struct {
 	cniTypes.NetConf
 	ENIName          string   `json:"eniName"`
 	ENIMACAddress    string   `json:"eniMACAddress"`
-	ENIIPAddress     string   `json:"eniIPAddress"`
+	ENIIPAddresses   []string `json:"eniIPAddresses"`
 	VPCCIDRs         []string `json:"vpcCIDRs"`
 	BridgeType       string   `json:"bridgeType"`
 	BridgeNetNSPath  string   `json:"bridgeNetNSPath"`
-	IPAddress        string   `json:"ipAddress"`
+	IPAddresses      []string `json:"ipAddresses"`
 	GatewayIPAddress string   `json:"gatewayIPAddress"`
 	InterfaceType    string   `json:"interfaceType"`
 	TapUserID        string   `json:"tapUserID"`
@@ -120,12 +120,13 @@ func New(args *cniSkel.CmdArgs, isAddCmd bool) (*NetConfig, error) {
 		}
 	}
 
-	// Parse the optional ENI IP address.
-	if config.ENIIPAddress != "" {
-		netConfig.ENIIPAddress, err = vpc.GetIPAddressFromString(config.ENIIPAddress)
+	// Parse the optional ENI IP addresses.
+	for _, eniIPString := range config.ENIIPAddresses {
+		eniIP, err := vpc.GetIPAddressFromString(eniIPString)
 		if err != nil {
-			return nil, fmt.Errorf("invalid ENIIPAddress %s", config.ENIIPAddress)
+			return nil, fmt.Errorf("invalid ENIIPAddress %s", eniIPString)
 		}
+		netConfig.ENIIPAddresses = append(netConfig.ENIIPAddresses, *eniIP)
 	}
 
 	// Parse the optional VPC CIDR blocks.
@@ -144,12 +145,13 @@ func New(args *cniSkel.CmdArgs, isAddCmd bool) (*NetConfig, error) {
 		return nil, fmt.Errorf("invalid BridgeType %s", config.BridgeType)
 	}
 
-	// Parse the optional IP address.
-	if config.IPAddress != "" {
-		netConfig.IPAddress, err = vpc.GetIPAddressFromString(config.IPAddress)
+	// Parse the optional IP addresses.
+	for _, ipString := range config.IPAddresses {
+		ipAddress, err := vpc.GetIPAddressFromString(ipString)
 		if err != nil {
-			return nil, fmt.Errorf("invalid IPAddress %s", config.IPAddress)
+			return nil, fmt.Errorf("invalid IPAddress %s", ipString)
 		}
+		netConfig.IPAddresses = append(netConfig.IPAddresses, *ipAddress)
 	}
 
 	// Parse the optional gateway IP address.

--- a/plugins/vpc-shared-eni/network/network.go
+++ b/plugins/vpc-shared-eni/network/network.go
@@ -34,7 +34,7 @@ type Network struct {
 	BridgeNetNSPath     string
 	BridgeIndex         int
 	SharedENI           *eni.ENI
-	ENIIPAddress        *net.IPNet
+	ENIIPAddresses      []net.IPNet
 	GatewayIPAddress    net.IP
 	VPCCIDRs            []net.IPNet
 	DNSServers          []string
@@ -50,5 +50,5 @@ type Endpoint struct {
 	IfType      string
 	TapUserID   int
 	MACAddress  net.HardwareAddr
-	IPAddress   *net.IPNet
+	IPAddresses []net.IPNet
 }

--- a/plugins/vpc-shared-eni/vpc-shared-eni.conf
+++ b/plugins/vpc-shared-eni/vpc-shared-eni.conf
@@ -4,9 +4,9 @@
   "type": "vpc-shared-eni",
   "eniName": "eth1",
   "eniMACAddress": "12:34:56:78:9a:bc",
-  "eniIPAddress": "192.168.1.42/24",
+  "eniIPAddresses": ["192.168.1.42/24"],
   "vpcCIDRs": ["192.168.0.0/16"],
   "bridgeNetNSPath": "",
-  "ipAddress": "192.168.1.43/24",
+  "ipAddresses": ["192.168.1.43/24"],
   "gatewayIPAddress": "192.168.1.1"
 }


### PR DESCRIPTION
*Issue #, if available:*
vpc shared eni does not support v6 addresses currently.

*Description of changes:*
Adding support within vpc shared eni to assign v6 address to eth0 interface in the pod network namespace.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
