### PR TITLE
Refactor Kubernetes-specific behavior in vpc-shared-eni

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
+github.com/Microsoft/go-winio v0.4.12 h1:xAfWHN1IrQ0NJ9TBC0KBZoqLjzDTr1ML+4MywiUOryc=
 github.com/Microsoft/go-winio v0.4.12/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
+github.com/Microsoft/hcsshim v0.7.12 h1:VCjS2UYlYyMfRnCus+yhbJZBi9DeFSMBKrggG/PAeHk=
 github.com/Microsoft/hcsshim v0.7.12/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/cihub/seelog v0.0.0-20151216151435-d2c6e5aa9fbf h1:XI2tOTCBqEnMyN2j1yPBI07yQHeywUSCEf8YWqf0oKw=
 github.com/cihub/seelog v0.0.0-20151216151435-d2c6e5aa9fbf/go.mod h1:9d6lWj8KzO/fd/NrVaLscBKmPigpZpn5YawRPw+e3Yo=

--- a/plugins/vpc-shared-eni/config/kubeapi.go
+++ b/plugins/vpc-shared-eni/config/kubeapi.go
@@ -51,7 +51,7 @@ func retrievePodConfig(netConfig *NetConfig) error {
 	}
 
 	var ipAddress string
-	kc := &netConfig.Kubernetes
+	kc := netConfig.Kubernetes
 
 	// Wait until the pod is annotated with an IP address resource label.
 	for i := 0; i < retries; i++ {
@@ -61,7 +61,7 @@ func retrievePodConfig(netConfig *NetConfig) error {
 		}
 
 		podAnnotations := pod.GetAnnotations()
-		ipAddress, _ = podAnnotations[vpcResourceNameIPv4Address]
+		ipAddress = podAnnotations[vpcResourceNameIPv4Address]
 		if ipAddress != "" {
 			break
 		}

--- a/plugins/vpc-shared-eni/config/kubernetes.go
+++ b/plugins/vpc-shared-eni/config/kubernetes.go
@@ -64,7 +64,7 @@ func parseKubernetesArgs(netConfig *NetConfig, args *cniSkel.CmdArgs, isAddCmd b
 		return fmt.Errorf("failed to parse runtime args: %v", err)
 	}
 
-	kc := &netConfig.Kubernetes
+	kc := netConfig.Kubernetes
 	kc.Namespace = string(ka.K8S_POD_NAMESPACE)
 	kc.PodName = string(ka.K8S_POD_NAME)
 	kc.PodInfraContainerID = string(ka.K8S_POD_INFRA_CONTAINER_ID)

--- a/plugins/vpc-shared-eni/config/netconfig.go
+++ b/plugins/vpc-shared-eni/config/netconfig.go
@@ -40,7 +40,7 @@ type NetConfig struct {
 	GatewayIPAddress net.IP
 	InterfaceType    string
 	TapUserID        int
-	Kubernetes       KubernetesConfig
+	Kubernetes       *KubernetesConfig
 }
 
 // netConfigJSON defines the network configuration JSON file format for the vpc-shared-eni plugin.
@@ -107,9 +107,6 @@ func New(args *cniSkel.CmdArgs, isAddCmd bool) (*NetConfig, error) {
 		BridgeType:      config.BridgeType,
 		BridgeNetNSPath: config.BridgeNetNSPath,
 		InterfaceType:   config.InterfaceType,
-		Kubernetes: KubernetesConfig{
-			ServiceCIDR: config.ServiceCIDR,
-		},
 	}
 
 	// Parse the ENI MAC address.
@@ -177,6 +174,10 @@ func New(args *cniSkel.CmdArgs, isAddCmd bool) (*NetConfig, error) {
 
 	// Parse orchestrator-specific configuration.
 	if strings.Contains(args.Args, "K8S") {
+		netConfig.Kubernetes = &KubernetesConfig{
+			ServiceCIDR: config.ServiceCIDR,
+		}
+
 		err = parseKubernetesArgs(&netConfig, args, isAddCmd)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse Kubernetes args: %v", err)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
A previous commit adding IPv6 support in vpc-shared-eni plugin has also introduced Kubernetes-specific behavior that breaks CNI specification. This change refactors Kubernetes-specific logic in vpc-shared-eni, so that the workaround only applies when the caller is Kubernetes data plane.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
