### PR TITLE
vpc-branch-pat-eni: properly check for nil

### DIFF
--- a/plugins/vpc-branch-pat-eni/config/netconfig.go
+++ b/plugins/vpc-branch-pat-eni/config/netconfig.go
@@ -103,10 +103,10 @@ func New(args *cniSkel.CmdArgs, isAdd bool) (*NetConfig, error) {
 	// Parse the optional branch IP address.
 	if config.BranchIPAddress != "" {
 		ipAddr, err := vpc.GetIPAddressFromString(config.BranchIPAddress)
-		netConfig.BranchIPAddress = *ipAddr
 		if err != nil {
 			return nil, fmt.Errorf("invalid branchIPAddress %s", config.BranchIPAddress)
 		}
+		netConfig.BranchIPAddress = *ipAddr
 	}
 
 	// Parse the optional TAP interface UID and GID.


### PR DESCRIPTION
*Description of changes:*
In the vpc-branch-pat-eni plugin, an optional branch IP address is parsed. In order to accomplish this, ipAddr is dereferenced. While err is checked against nil, the check is after ipAddr is dereferenced, which may result in a nil pointer dereference panic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
