### PR TITLE
Fix vpc-shared-eni build flag for Kubernetes

### DIFF
--- a/plugins/vpc-shared-eni/config/kubeapi.go
+++ b/plugins/vpc-shared-eni/config/kubeapi.go
@@ -11,7 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// +build !disablekubeapi
+// +build enablekubeapi
+//go:build enablekubeapi
 
 package config
 


### PR DESCRIPTION
We are changing Kubernetes build flag from opt-out to opt-in, so that by
default plain CNI plugin builds won't have to build Kubernetes packages.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
