### PR TITLE
Add missing logging in branch and tunnel plugins

### DIFF
--- a/plugins/vpc-branch-eni/plugin/commands.go
+++ b/plugins/vpc-branch-eni/plugin/commands.go
@@ -256,6 +256,9 @@ func (plugin *Plugin) Del(args *cniSkel.CmdArgs) error {
 
 			return nil
 		})
+		if err != nil {
+			log.Errorf("Failed to set netns %s, ignoring: %v.", args.Netns, err)
+		}
 	} else {
 		// Log and ignore the failure. DEL can be called multiple times and thus must be idempotent.
 		log.Errorf("Failed to find netns %s, ignoring: %v.", args.Netns, err)

--- a/plugins/vpc-tunnel/plugin/commands.go
+++ b/plugins/vpc-tunnel/plugin/commands.go
@@ -194,6 +194,9 @@ func (plugin *Plugin) Del(args *cniSkel.CmdArgs) error {
 
 			return nil
 		})
+		if err != nil {
+			log.Errorf("Failed to set netns %s, ignoring: %v.", args.Netns, err)
+		}
 	} else {
 		// Log and ignore the failure. DEL can be called multiple times and thus must be idempotent.
 		log.Errorf("Failed to find netns %s, ignoring: %v.", args.Netns, err)


### PR DESCRIPTION
A specific error returned while deleting resources inside a network
namespace was not logged. Added the log to improve visibility.

*Description of changes:* The branch and tunnel plugins executes a function inside a network namespace as part of their DEL workflow. Sometimes we noticed there are chances that execution of that function inside the network namespace fail due to unknown reasons. A certain error in the workflow was noticed to be not logged. This change ensure that error is logged so that we will have better visibility.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
