### PR TITLE
Multiple rules for ignoring egress ports

### DIFF
--- a/plugins/aws-appmesh/config/netconfig.go
+++ b/plugins/aws-appmesh/config/netconfig.go
@@ -35,7 +35,7 @@ type NetConfig struct {
 	IgnoredGID         string
 	ProxyIngressPort   string
 	ProxyEgressPort    string
-	AppPorts           string
+	AppPorts           []string
 	EgressIgnoredPorts []string
 	EgressIgnoredIPv4s string
 	EgressIgnoredIPv6s string
@@ -58,7 +58,7 @@ type netConfigJSON struct {
 }
 
 const (
-	splitter  = ","
+	Splitter  = ","
 	ipv4Proto = "IPv4"
 	ipv6Proto = "IPv6"
 )
@@ -89,7 +89,7 @@ func New(args *cniSkel.CmdArgs) (*NetConfig, error) {
 		IgnoredGID:         config.IgnoredGID,
 		ProxyIngressPort:   config.ProxyIngressPort,
 		ProxyEgressPort:    config.ProxyEgressPort,
-		AppPorts:           strings.Join(config.AppPorts, splitter),
+		AppPorts:           config.AppPorts,
 		EgressIgnoredIPv4s: ipv4s,
 		EgressIgnoredIPv6s: ipv6s,
 		EgressIgnoredPorts: config.EgressIgnoredPorts,
@@ -187,7 +187,7 @@ func separateIPs(ignoredIPs []string) (string, string, error) {
 		}
 
 	}
-	return strings.Join(ipv4s, splitter), strings.Join(ipv6s, splitter), nil
+	return strings.Join(ipv4s, Splitter), strings.Join(ipv6s, Splitter), nil
 }
 
 // isValidPort checks whether the port only has digits.

--- a/plugins/aws-appmesh/config/netconfig.go
+++ b/plugins/aws-appmesh/config/netconfig.go
@@ -58,7 +58,7 @@ type netConfigJSON struct {
 }
 
 const (
-	Splitter  = ","
+	splitter  = ","
 	ipv4Proto = "IPv4"
 	ipv6Proto = "IPv6"
 )
@@ -187,7 +187,7 @@ func separateIPs(ignoredIPs []string) (string, string, error) {
 		}
 
 	}
-	return strings.Join(ipv4s, Splitter), strings.Join(ipv6s, Splitter), nil
+	return strings.Join(ipv4s, splitter), strings.Join(ipv6s, splitter), nil
 }
 
 // isValidPort checks whether the port only has digits.

--- a/plugins/aws-appmesh/config/netconfig.go
+++ b/plugins/aws-appmesh/config/netconfig.go
@@ -36,7 +36,7 @@ type NetConfig struct {
 	ProxyIngressPort   string
 	ProxyEgressPort    string
 	AppPorts           string
-	EgressIgnoredPorts string
+	EgressIgnoredPorts []string
 	EgressIgnoredIPv4s string
 	EgressIgnoredIPv6s string
 	EnableIPv6         bool
@@ -92,7 +92,7 @@ func New(args *cniSkel.CmdArgs) (*NetConfig, error) {
 		AppPorts:           strings.Join(config.AppPorts, splitter),
 		EgressIgnoredIPv4s: ipv4s,
 		EgressIgnoredIPv6s: ipv6s,
-		EgressIgnoredPorts: strings.Join(config.EgressIgnoredPorts, splitter),
+		EgressIgnoredPorts: config.EgressIgnoredPorts,
 		EnableIPv6:         config.EnableIPv6,
 	}
 

--- a/plugins/aws-appmesh/config/netconfig_test.go
+++ b/plugins/aws-appmesh/config/netconfig_test.go
@@ -98,8 +98,8 @@ func TestNew(t *testing.T) {
 	assert.Equal(t, "", config.IgnoredGID)
 	assert.Equal(t, "8080", config.ProxyIngressPort)
 	assert.Equal(t, "8000", config.ProxyEgressPort)
-	assert.Equal(t, "1223,2334", config.AppPorts)
-	assert.Equal(t, "80,81", config.EgressIgnoredPorts)
+	assert.Equal(t, []string{"1223", "2334"}, config.AppPorts)
+	assert.Equal(t, []string{"80", "81"}, config.EgressIgnoredPorts)
 	assert.Equal(t, "216.3.128.12,216.3.128.12/24", config.EgressIgnoredIPv4s)
 	assert.Equal(t, "2001:0db8:85a3:0000:0000:8a2e:0370:7334", config.EgressIgnoredIPv6s)
 

--- a/plugins/aws-appmesh/plugin/commands.go
+++ b/plugins/aws-appmesh/plugin/commands.go
@@ -212,30 +212,6 @@ func (plugin *Plugin) setupEgressRules(
 	return nil
 }
 
-func eachNSlice(ss []string, n int, f func([]string) error) error {
-	s := make([]string, n)
-
-	for i, val := range ss {
-		s = append(s, val)
-
-		if (i+1)%n == 0 {
-			if err := f(s); err != nil {
-				return err
-			}
-
-			s = []string{}
-		}
-	}
-
-	if len(s) > 0 {
-		if err := f(s); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // setupIngressRules installs iptable rules to handle ingress traffic.
 func (plugin *Plugin) setupIngressRules(
 	iptable *iptables.IPTables,
@@ -343,6 +319,30 @@ func (plugin *Plugin) deleteEgressRules(iptable *iptables.IPTables) error {
 	if err != nil {
 		log.Errorf("Failed to delete chain[%v]: %v", egressChain, err)
 		return err
+	}
+
+	return nil
+}
+
+func eachNSlice(ss []string, n int, f func([]string) error) error {
+	s := make([]string, n)
+
+	for i, val := range ss {
+		s = append(s, val)
+
+		if (i+1)%n == 0 {
+			if err := f(s); err != nil {
+				return err
+			}
+
+			s = []string{}
+		}
+	}
+
+	if len(s) > 0 {
+		if err := f(s); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/plugins/aws-appmesh/plugin/commands.go
+++ b/plugins/aws-appmesh/plugin/commands.go
@@ -173,11 +173,12 @@ func (plugin *Plugin) setupEgressRules(
 	}
 
 	if config.EgressIgnoredPorts != "" {
-		err = iptable.Append("nat", egressChain, "-p", "tcp", "-m", "multiport", "--dports",
-			config.EgressIgnoredPorts, "-j", "RETURN")
-		if err != nil {
-			log.Errorf("Append rule for egressIgnoredPorts failed: %v", err)
-			return err
+		for _, port := range config.EgressIgnoredPorts {
+			err = iptable.Append("nat", egressChain, "-p", "tcp", "-m", "multiport", "--dports", port, "-j", "RETURN")
+			if err != nil {
+				log.Errorf("Append rule for egressIgnoredPorts failed: %v", err)
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-app-mesh-roadmap/issues/269

*Description of changes:*
Ignore egress ports using multiple iptables rules. This is a workaround for iptables limit of 15 ports per rule. https://linux.die.net/man/8/iptables. Some customers require ignoring more than 15 ports.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
