### PR TITLE
Setting bridge proxy delay to 0

### DIFF
--- a/network/ipcfg/ip.go
+++ b/network/ipcfg/ip.go
@@ -23,6 +23,7 @@ import (
 const (
 	ipv4Forwarding = "/proc/sys/net/ipv4/conf/%s/forwarding"
 	ipv4ProxyARP   = "/proc/sys/net/ipv4/conf/%s/proxy_arp"
+	ipv4ProxyDelay = "/proc/sys/net/ipv4/neigh/%s/proxy_delay"
 
 	ipv6Forwarding = "/proc/sys/net/ipv6/conf/%s/forwarding"
 	ipv6AcceptRA   = "/proc/sys/net/ipv6/conf/%s/accept_ra"
@@ -37,6 +38,11 @@ func SetIPv4Forwarding(ifName string, value int) error {
 // SetIPv4ProxyARP sets the IPv4 proxy ARP property of an interface to the given value.
 func SetIPv4ProxyARP(ifName string, value int) error {
 	return set(fmt.Sprintf(ipv4ProxyARP, ifName), value)
+}
+
+// SetIPv4ProxyDelay sets the IPv4 delay before responding to proxy ARP
+func SetIPv4ProxyDelay(ifName string, value int) error {
+	return set(fmt.Sprintf(ipv4ProxyDelay, ifName), value)
 }
 
 // SetIPv6Forwarding sets the IPv6 forwarding property of an interface to the given value.

--- a/plugins/vpc-shared-eni/network/bridge_linux.go
+++ b/plugins/vpc-shared-eni/network/bridge_linux.go
@@ -546,6 +546,13 @@ func (nb *BridgeBuilder) createBridge(
 				log.Errorf("Failed to enable IPv4 forwarding on %s: %v.", sharedENI.GetLinkName(), err)
 				return 0, err
 			}
+
+			// Set IPv4 proxy delay to 0 to avoid ARP proxy delays
+			log.Infof("Setting IPv4 proxy delay on %s.", sharedENI.GetLinkName())
+			err = ipcfg.SetIPv4ProxyDelay(sharedENI.GetLinkName(), 0)
+			if err != nil {
+				log.Errorf("Failed to set IPv4 proxy delay on %s: %v", sharedENI.GetLinkName(), err)
+			}
 		}
 
 		if vpc.ListContainsIPv6Address(ipAddresses) {


### PR DESCRIPTION
For issue https://github.com/aws/amazon-vpc-cni-plugins/issues/78

Setting the bridge proxy delay to 0. This is to prevent the ARP proxy delays EKS Fargate has seen in production.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
