### PR TITLE
Added 0.4.0 in supported CNI Spec version list

### DIFF
--- a/plugins/vpc-shared-eni/plugin/plugin.go
+++ b/plugins/vpc-shared-eni/plugin/plugin.go
@@ -30,7 +30,7 @@ const (
 
 var (
 	// specVersions is the set of CNI spec versions supported by this plugin.
-	specVersions = cniVersion.PluginSupports("0.3.0", "0.3.1")
+	specVersions = cniVersion.PluginSupports("0.3.0", "0.3.1", "0.4.0")
 )
 
 // Plugin represents a vpc-shared-eni CNI plugin.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added 0.4.0 to Supported CNI spec list for vpc-shared-eni plugin. k8s 1.24 requires 0.4.0 CNI Spec.

*Testing:*
I have tested this change in 1.24 Windows EKS AMIs. Sanity tests and functional tests passed with this change.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
