### PR TITLE
AppMesh plugin: Make delete idempotent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Microsoft/hcsshim v0.7.12
 	github.com/cihub/seelog v0.0.0-20151216151435-d2c6e5aa9fbf
 	github.com/containernetworking/cni v0.8.1
-	github.com/coreos/go-iptables v0.4.0
+	github.com/coreos/go-iptables v0.6.0
 	github.com/stretchr/testify v1.2.2
 	github.com/vishvananda/netlink v1.1.1-0.20210316144550-c21bda41e995
 	golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/containernetworking/cni v0.8.1 h1:7zpDnQ3T3s4ucOuJ/ZCLrYBxzkg0AELFfII
 github.com/containernetworking/cni v0.8.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/coreos/go-iptables v0.4.0 h1:wh4UbVs8DhLUbpyq97GLJDKrQMjEDD63T1xE4CrsKzQ=
 github.com/coreos/go-iptables v0.4.0/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
+github.com/coreos/go-iptables v0.6.0 h1:is9qnZMPYjLd8LYqmm/qlE+wwEgJIkTYdhV3rfZo4jk=
+github.com/coreos/go-iptables v0.6.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/plugins/aws-appmesh/e2eTests/e2e_test.go
+++ b/plugins/aws-appmesh/e2eTests/e2e_test.go
@@ -11,8 +11,8 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-//go:build e2e-test
-// +build e2e-test
+//go:build e2e_test
+// +build e2e_test
 
 package e2e
 

--- a/plugins/aws-appmesh/e2eTests/testdata/invalid_without_app_ports.json
+++ b/plugins/aws-appmesh/e2eTests/testdata/invalid_without_app_ports.json
@@ -1,6 +1,7 @@
 {
     "type": "aws-appmesh",
     "cniVersion": "0.3.0",
+    "name":"aws-appmesh-cni-plugin",
     "ignoredUID": "1337",
     "ignoredGID": "133",
     "proxyEgressPort": "8080",

--- a/plugins/aws-appmesh/e2eTests/testdata/invalid_without_proxy_egress_port.json
+++ b/plugins/aws-appmesh/e2eTests/testdata/invalid_without_proxy_egress_port.json
@@ -1,6 +1,7 @@
 {
     "type": "aws-appmesh",
     "cniVersion": "0.3.0",
+    "name":"aws-appmesh-cni-plugin",
     "ignoredUID": "1337",
     "ignoredGID": "133",
     "proxyIngressPort": "8000",

--- a/plugins/aws-appmesh/e2eTests/testdata/invalid_without_proxy_ingress_port.json
+++ b/plugins/aws-appmesh/e2eTests/testdata/invalid_without_proxy_ingress_port.json
@@ -1,6 +1,7 @@
 {
     "type": "aws-appmesh",
     "cniVersion": "0.3.0",
+    "name":"aws-appmesh-cni-plugin",
     "ignoredUID": "1337",
     "ignoredGID": "133",
     "proxyEgressPort": "8080",

--- a/plugins/aws-appmesh/e2eTests/testdata/valid_ingress_egress.json
+++ b/plugins/aws-appmesh/e2eTests/testdata/valid_ingress_egress.json
@@ -4,6 +4,7 @@
     },
     "type": "aws-appmesh",
     "cniVersion": "0.3.0",
+    "name":"aws-appmesh-cni-plugin",
     "ignoredUID": "1337",
     "ignoredGID": "133",
     "proxyEgressPort": "8080",

--- a/plugins/aws-appmesh/e2eTests/testdata/valid_with_multiports.json
+++ b/plugins/aws-appmesh/e2eTests/testdata/valid_with_multiports.json
@@ -1,0 +1,44 @@
+{
+    "prevResult": {
+        "IPs": [{"Version":"4","Address":"10.1.2.3/16"}]
+    },
+    "type": "aws-appmesh",
+    "cniVersion": "0.3.0",
+    "name":"aws-appmesh-cni-plugin",
+    "ignoredUID": "1337",
+    "ignoredGID": "133",
+    "proxyEgressPort": "8080",
+    "proxyIngressPort": "8000",
+    "appPorts": [
+        "5000",
+        "5001"
+    ],
+    "egressIgnoredPorts": [
+        "80",
+        "81",
+        "82",
+        "83",
+        "84",
+        "85",
+        "86",
+        "87",
+        "88",
+        "89",
+        "90",
+        "91",
+        "92",
+        "93",
+        "94",
+        "95",
+        "96",
+        "97",
+        "98",
+        "99"
+    ],
+    "egressIgnoredIPs": [
+        "192.168.100.0/22",
+        "163.107.163.107",
+        "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+    ],
+    "enableIPv6": true
+}

--- a/plugins/aws-appmesh/e2eTests/testdata/valid_without_ingress.json
+++ b/plugins/aws-appmesh/e2eTests/testdata/valid_without_ingress.json
@@ -4,6 +4,7 @@
     },
     "type": "aws-appmesh",
     "cniVersion": "0.3.0",
+    "name":"aws-appmesh-cni-plugin",
     "ignoredUID": "1337",
     "ignoredGID": "133",
     "proxyEgressPort": "8080",

--- a/plugins/aws-appmesh/plugin/commands.go
+++ b/plugins/aws-appmesh/plugin/commands.go
@@ -319,6 +319,7 @@ func (plugin *Plugin) deleteIngressRules(
 	err = iptable.ClearChain("nat", ingressChain)
 	if err != nil {
 		log.Errorf("Failed to flush rules in chain[%v]: %v", ingressChain, err)
+		return err
 	}
 	err = iptable.DeleteChain("nat", ingressChain)
 	if err != nil {
@@ -355,6 +356,7 @@ func (plugin *Plugin) deleteEgressRules(iptable *iptables.IPTables) error {
 	err = iptable.ClearChain("nat", egressChain)
 	if err != nil {
 		log.Errorf("Failed to flush rules in chain[%v]: %v", egressChain, err)
+		return err
 	}
 	err = iptable.DeleteChain("nat", egressChain)
 	if err != nil {

--- a/plugins/aws-appmesh/plugin/commands.go
+++ b/plugins/aws-appmesh/plugin/commands.go
@@ -270,23 +270,6 @@ func (plugin *Plugin) deleteIptablesRules(
 	return nil
 }
 
-//Check if a chain exists in an iptable
-func (plugin *Plugin) checkChainExists(chainName string, iptable *iptables.IPTables) (bool, error) {
-	exists := false
-	chains, err := iptable.ListChains("nat")
-	if err != nil {
-		log.Errorf("failed to list chains: %v", err)
-		return false, err
-	}
-	for _, ch := range chains {
-		if ch == chainName {
-			exists = true
-			break
-		}
-	}
-	return exists, nil
-}
-
 // deleteIngressRules deletes the iptable rules for ingress traffic.
 func (plugin *Plugin) deleteIngressRules(
 	iptable *iptables.IPTables,
@@ -296,7 +279,7 @@ func (plugin *Plugin) deleteIngressRules(
 	}
 
 	//Check if ingress chain exist before deleting
-	exists, err := plugin.checkChainExists(ingressChain, iptable)
+	exists, err := iptable.ChainExists("nat", ingressChain)
 	if err != nil {
 		return err
 	}
@@ -334,7 +317,7 @@ func (plugin *Plugin) deleteIngressRules(
 func (plugin *Plugin) deleteEgressRules(iptable *iptables.IPTables) error {
 
 	//Check if ingress chain exist before deleting
-	exists, err := plugin.checkChainExists(egressChain, iptable)
+	exists, err := iptable.ChainExists("nat", egressChain)
 	if err != nil {
 		return err
 	}

--- a/plugins/aws-appmesh/plugin/commands.go
+++ b/plugins/aws-appmesh/plugin/commands.go
@@ -370,8 +370,8 @@ func forEachSlice(inputPorts []string, maximumPort int, run func([]string) error
 
 	for i, port := range inputPorts {
 		//Ignore ports after reaching multiport limit
-		if i == maximumPort-1 {
-			log.Error("multiport limit: %d exceeded, ignoring remaining rules", maximumPort)
+		if i == maximumPort {
+			log.Errorf("multiport limit: %d exceeded, ignoring remaining rules", maximumPort)
 			break
 		}
 		portList = append(portList, port)

--- a/plugins/aws-appmesh/plugin/commands.go
+++ b/plugins/aws-appmesh/plugin/commands.go
@@ -277,9 +277,30 @@ func (plugin *Plugin) deleteIngressRules(
 	if config.ProxyIngressPort == "" {
 		return nil
 	}
+
+	//Check if ingress chain exist before deleting
+	exists := false
+	chains, err := iptable.ListChains("nat")
+	if err != nil {
+		log.Errorf("failed to list chains: %v", err)
+		return err
+	}
+	for _, ch := range chains {
+		if ch == ingressChain {
+			exists = true
+			break
+		}
+	}
+	//return nil to make sure deleting process is idempotent
+	if !exists {
+		log.Warn("deleting a non-existent ingress chain: %s", ingressChain)
+		return nil
+	}
+
 	// Delete ingress rule from iptables.
-	err := iptable.Delete("nat", "PREROUTING", "-p", "tcp", "-m", "addrtype", "!", "--src-type",
+	err = iptable.Delete("nat", "PREROUTING", "-p", "tcp", "-m", "addrtype", "!", "--src-type",
 		"LOCAL", "-j", ingressChain)
+
 	if err != nil {
 		log.Errorf("Delete the rule in PREROUTING chain failed: %v", err)
 		return err
@@ -302,8 +323,27 @@ func (plugin *Plugin) deleteIngressRules(
 
 // deleteEgressRules deletes the iptable rules for egress traffic.
 func (plugin *Plugin) deleteEgressRules(iptable *iptables.IPTables) error {
+
+	// Check if egress chain exist before deleting
+	exists := false
+	chains, err := iptable.ListChains("nat")
+	if err != nil {
+		return log.Errorf("failed to list chains: %v", err)
+	}
+	for _, ch := range chains {
+		if ch == egressChain {
+			exists = true
+			break
+		}
+	}
+	//return nil to make sure deleting process is idempotent
+	if !exists {
+		log.Warn("deleting a non-existent egress chain: %s", egressChain)
+		return nil
+	}
+
 	// Delete egress rule from iptables.
-	err := iptable.Delete("nat", "OUTPUT", "-p", "tcp", "-m", "addrtype", "!", "--dst-type",
+	err = iptable.Delete("nat", "OUTPUT", "-p", "tcp", "-m", "addrtype", "!", "--dst-type",
 		"LOCAL", "-j", egressChain)
 	if err != nil {
 		log.Errorf("Delete the rule in OUTPUT chain failed: %v", err)
@@ -325,23 +365,21 @@ func (plugin *Plugin) deleteEgressRules(iptable *iptables.IPTables) error {
 	return nil
 }
 
-func forEachSlice(ss []string, size int, f func([]string) error) error {
-	s := make([]string, size)
+func forEachSlice(inputPorts []string, maximumPort int, run func([]string) error) error {
+	portList := make([]string, 0)
 
-	for i, val := range ss {
-		s = append(s, val)
-
-		if (i+1)%size == 0 {
-			if err := f(s); err != nil {
-				return err
-			}
-
-			s = []string{}
+	for i, port := range inputPorts {
+		//Ignore ports after reaching multiport limit
+		if i == maximumPort-1 {
+			log.Error("multiport limit: %d exceeded, ignoring remaining rules", maximumPort)
+			break
 		}
+		portList = append(portList, port)
 	}
 
-	if len(s) > 0 {
-		if err := f(s); err != nil {
+	if len(portList) > 0 {
+		err := run(portList)
+		if err != nil {
 			return err
 		}
 	}

--- a/plugins/aws-appmesh/plugin/commands.go
+++ b/plugins/aws-appmesh/plugin/commands.go
@@ -319,7 +319,6 @@ func (plugin *Plugin) deleteIngressRules(
 	err = iptable.ClearChain("nat", ingressChain)
 	if err != nil {
 		log.Errorf("Failed to flush rules in chain[%v]: %v", ingressChain, err)
-		return err
 	}
 	err = iptable.DeleteChain("nat", ingressChain)
 	if err != nil {
@@ -356,7 +355,6 @@ func (plugin *Plugin) deleteEgressRules(iptable *iptables.IPTables) error {
 	err = iptable.ClearChain("nat", egressChain)
 	if err != nil {
 		log.Errorf("Failed to flush rules in chain[%v]: %v", egressChain, err)
-		return err
 	}
 	err = iptable.DeleteChain("nat", egressChain)
 	if err != nil {

--- a/plugins/ecs-serviceconnect/testdata/invalid_egress_ipv4_cidr_1.json
+++ b/plugins/ecs-serviceconnect/testdata/invalid_egress_ipv4_cidr_1.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "ingressConfig": [
     {

--- a/plugins/ecs-serviceconnect/testdata/invalid_egress_ipv4_cidr_2.json
+++ b/plugins/ecs-serviceconnect/testdata/invalid_egress_ipv4_cidr_2.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "ingressConfig": [
     {

--- a/plugins/ecs-serviceconnect/testdata/invalid_egress_ipv6_cidr_1.json
+++ b/plugins/ecs-serviceconnect/testdata/invalid_egress_ipv6_cidr_1.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "ingressConfig": [
     {

--- a/plugins/ecs-serviceconnect/testdata/invalid_egress_ipv6_cidr_2.json
+++ b/plugins/ecs-serviceconnect/testdata/invalid_egress_ipv6_cidr_2.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "ingressConfig": [
     {

--- a/plugins/ecs-serviceconnect/testdata/invalid_egress_listener_port.json
+++ b/plugins/ecs-serviceconnect/testdata/invalid_egress_listener_port.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "ingressConfig": [
     {

--- a/plugins/ecs-serviceconnect/testdata/invalid_egress_redirect_ip_1.json
+++ b/plugins/ecs-serviceconnect/testdata/invalid_egress_redirect_ip_1.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "egressConfig": {
     "listenerName": "outbound_listener",

--- a/plugins/ecs-serviceconnect/testdata/invalid_egress_redirect_ip_2.json
+++ b/plugins/ecs-serviceconnect/testdata/invalid_egress_redirect_ip_2.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "egressConfig": {
     "listenerName": "outbound_listener",

--- a/plugins/ecs-serviceconnect/testdata/invalid_egress_redirect_ip_3.json
+++ b/plugins/ecs-serviceconnect/testdata/invalid_egress_redirect_ip_3.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "egressConfig": {
     "listenerName": "outbound_listener",

--- a/plugins/ecs-serviceconnect/testdata/invalid_empty_egress.json
+++ b/plugins/ecs-serviceconnect/testdata/invalid_empty_egress.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "ingressConfig": [
     {

--- a/plugins/ecs-serviceconnect/testdata/invalid_empty_egress_vip.json
+++ b/plugins/ecs-serviceconnect/testdata/invalid_empty_egress_vip.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "ingressConfig": [
     {

--- a/plugins/ecs-serviceconnect/testdata/invalid_ingress_intercept_port.json
+++ b/plugins/ecs-serviceconnect/testdata/invalid_ingress_intercept_port.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "ingressConfig": [
     {

--- a/plugins/ecs-serviceconnect/testdata/invalid_ingress_listener_port.json
+++ b/plugins/ecs-serviceconnect/testdata/invalid_ingress_listener_port.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "ingressConfig": [
     {

--- a/plugins/ecs-serviceconnect/testdata/invalid_missing_egress_listener_port.json
+++ b/plugins/ecs-serviceconnect/testdata/invalid_missing_egress_listener_port.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "ingressConfig": [
     {

--- a/plugins/ecs-serviceconnect/testdata/invalid_missing_egress_vip.json
+++ b/plugins/ecs-serviceconnect/testdata/invalid_missing_egress_vip.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "ingressConfig": [
     {

--- a/plugins/ecs-serviceconnect/testdata/invalid_missing_ingress_egress.json
+++ b/plugins/ecs-serviceconnect/testdata/invalid_missing_ingress_egress.json
@@ -1,4 +1,5 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0"
 }

--- a/plugins/ecs-serviceconnect/testdata/invalid_missing_ingress_listener_port.json
+++ b/plugins/ecs-serviceconnect/testdata/invalid_missing_ingress_listener_port.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "ingressConfig": [
     {

--- a/plugins/ecs-serviceconnect/testdata/invalid_missing_ip.json
+++ b/plugins/ecs-serviceconnect/testdata/invalid_missing_ip.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "ingressConfig": [
     {

--- a/plugins/ecs-serviceconnect/testdata/invalid_missing_redirect_mode.json
+++ b/plugins/ecs-serviceconnect/testdata/invalid_missing_redirect_mode.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "egressConfig": {
     "listenerName": "outbound_listener",

--- a/plugins/ecs-serviceconnect/testdata/invalid_redirect_mode.json
+++ b/plugins/ecs-serviceconnect/testdata/invalid_redirect_mode.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "egressConfig": {
     "listenerName": "outbound_listener",

--- a/plugins/ecs-serviceconnect/testdata/invalid_v6_missing_egress_vip.json
+++ b/plugins/ecs-serviceconnect/testdata/invalid_v6_missing_egress_vip.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "ingressConfig": [
     {

--- a/plugins/ecs-serviceconnect/testdata/valid_empty_ingress.json
+++ b/plugins/ecs-serviceconnect/testdata/valid_empty_ingress.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "ingressConfig": [
   ],

--- a/plugins/ecs-serviceconnect/testdata/valid_ingress_with_port_intercept_1.json
+++ b/plugins/ecs-serviceconnect/testdata/valid_ingress_with_port_intercept_1.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "ingressConfig": [
     {

--- a/plugins/ecs-serviceconnect/testdata/valid_ingress_with_port_intercept_2.json
+++ b/plugins/ecs-serviceconnect/testdata/valid_ingress_with_port_intercept_2.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "ingressConfig": [
     {

--- a/plugins/ecs-serviceconnect/testdata/valid_ingress_without_port_intercept.json
+++ b/plugins/ecs-serviceconnect/testdata/valid_ingress_without_port_intercept.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "ingressConfig": [
     {

--- a/plugins/ecs-serviceconnect/testdata/valid_tproxy_redirect_ip.json
+++ b/plugins/ecs-serviceconnect/testdata/valid_tproxy_redirect_ip.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "egressConfig": {
     "redirectIP": {

--- a/plugins/ecs-serviceconnect/testdata/valid_tproxy_redirect_port.json
+++ b/plugins/ecs-serviceconnect/testdata/valid_tproxy_redirect_port.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "ingressConfig": [
     {

--- a/plugins/ecs-serviceconnect/testdata/valid_without_egress.json
+++ b/plugins/ecs-serviceconnect/testdata/valid_without_egress.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "ingressConfig": [
     {

--- a/plugins/ecs-serviceconnect/testdata/valid_without_ingress.json
+++ b/plugins/ecs-serviceconnect/testdata/valid_without_ingress.json
@@ -1,5 +1,6 @@
 {
   "type": "ecs-serviceconnect",
+  "name": "serviceconnect-cni-test-config",
   "cniVersion": "0.3.0",
   "egressConfig": {
     "listenerName": "outbound_listener",

--- a/vendor/github.com/coreos/go-iptables/iptables/iptables.go
+++ b/vendor/github.com/coreos/go-iptables/iptables/iptables.go
@@ -309,7 +309,7 @@ func (ipt *IPTables) ClearChain(table, chain string) error {
 	// different iptables modes
 	existsErr := 1
 	if ipt.mode == "nf_tables" {
-		existsErr = 4
+		existsErr = 1
 	}
 
 	eerr, eok := err.(*Error)

--- a/vendor/github.com/coreos/go-iptables/iptables/iptables.go
+++ b/vendor/github.com/coreos/go-iptables/iptables/iptables.go
@@ -47,9 +47,12 @@ func (e *Error) Error() string {
 
 // IsNotExist returns true if the error is due to the chain or rule not existing
 func (e *Error) IsNotExist() bool {
-	return e.ExitStatus() == 1 &&
-		(e.msg == "iptables: Bad rule (does a matching rule exist in that chain?).\n" ||
-			e.msg == "iptables: No chain/target/match by that name.\n")
+	if e.ExitStatus() != 1 {
+		return false
+	}
+	msgNoRuleExist := "Bad rule (does a matching rule exist in that chain?).\n"
+	msgNoChainExist := "No chain/target/match by that name.\n"
+	return strings.Contains(e.msg, msgNoRuleExist) || strings.Contains(e.msg, msgNoChainExist)
 }
 
 // Protocol to differentiate between IPv4 and IPv6
@@ -61,47 +64,95 @@ const (
 )
 
 type IPTables struct {
-	path           string
-	proto          Protocol
-	hasCheck       bool
-	hasWait        bool
-	hasRandomFully bool
-	v1             int
-	v2             int
-	v3             int
-	mode           string // the underlying iptables operating mode, e.g. nf_tables
+	path              string
+	proto             Protocol
+	hasCheck          bool
+	hasWait           bool
+	waitSupportSecond bool
+	hasRandomFully    bool
+	v1                int
+	v2                int
+	v3                int
+	mode              string // the underlying iptables operating mode, e.g. nf_tables
+	timeout           int    // time to wait for the iptables lock, default waits forever
 }
 
-// New creates a new IPTables.
-// For backwards compatibility, this always uses IPv4, i.e. "iptables".
-func New() (*IPTables, error) {
-	return NewWithProtocol(ProtocolIPv4)
+// Stat represents a structured statistic entry.
+type Stat struct {
+	Packets     uint64     `json:"pkts"`
+	Bytes       uint64     `json:"bytes"`
+	Target      string     `json:"target"`
+	Protocol    string     `json:"prot"`
+	Opt         string     `json:"opt"`
+	Input       string     `json:"in"`
+	Output      string     `json:"out"`
+	Source      *net.IPNet `json:"source"`
+	Destination *net.IPNet `json:"destination"`
+	Options     string     `json:"options"`
+}
+
+type option func(*IPTables)
+
+func IPFamily(proto Protocol) option {
+	return func(ipt *IPTables) {
+		ipt.proto = proto
+	}
+}
+
+func Timeout(timeout int) option {
+	return func(ipt *IPTables) {
+		ipt.timeout = timeout
+	}
+}
+
+// New creates a new IPTables configured with the options passed as parameter.
+// For backwards compatibility, by default always uses IPv4 and timeout 0.
+// i.e. you can create an IPv6 IPTables using a timeout of 5 seconds passing
+// the IPFamily and Timeout options as follow:
+//	ip6t := New(IPFamily(ProtocolIPv6), Timeout(5))
+func New(opts ...option) (*IPTables, error) {
+
+	ipt := &IPTables{
+		proto:   ProtocolIPv4,
+		timeout: 0,
+	}
+
+	for _, opt := range opts {
+		opt(ipt)
+	}
+
+	path, err := exec.LookPath(getIptablesCommand(ipt.proto))
+	if err != nil {
+		return nil, err
+	}
+	ipt.path = path
+
+	vstring, err := getIptablesVersionString(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not get iptables version: %v", err)
+	}
+	v1, v2, v3, mode, err := extractIptablesVersion(vstring)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract iptables version from [%s]: %v", vstring, err)
+	}
+	ipt.v1 = v1
+	ipt.v2 = v2
+	ipt.v3 = v3
+	ipt.mode = mode
+
+	checkPresent, waitPresent, waitSupportSecond, randomFullyPresent := getIptablesCommandSupport(v1, v2, v3)
+	ipt.hasCheck = checkPresent
+	ipt.hasWait = waitPresent
+	ipt.waitSupportSecond = waitSupportSecond
+	ipt.hasRandomFully = randomFullyPresent
+
+	return ipt, nil
 }
 
 // New creates a new IPTables for the given proto.
 // The proto will determine which command is used, either "iptables" or "ip6tables".
 func NewWithProtocol(proto Protocol) (*IPTables, error) {
-	path, err := exec.LookPath(getIptablesCommand(proto))
-	if err != nil {
-		return nil, err
-	}
-	vstring, err := getIptablesVersionString(path)
-	v1, v2, v3, mode, err := extractIptablesVersion(vstring)
-
-	checkPresent, waitPresent, randomFullyPresent := getIptablesCommandSupport(v1, v2, v3)
-
-	ipt := IPTables{
-		path:           path,
-		proto:          proto,
-		hasCheck:       checkPresent,
-		hasWait:        waitPresent,
-		hasRandomFully: randomFullyPresent,
-		v1:             v1,
-		v2:             v2,
-		v3:             v3,
-		mode:           mode,
-	}
-	return &ipt, nil
+	return New(IPFamily(proto), Timeout(0))
 }
 
 // Proto returns the protocol used by this IPTables.
@@ -160,6 +211,14 @@ func (ipt *IPTables) Delete(table, chain string, rulespec ...string) error {
 	return ipt.run(cmd...)
 }
 
+func (ipt *IPTables) DeleteIfExists(table, chain string, rulespec ...string) error {
+	exists, err := ipt.Exists(table, chain, rulespec...)
+	if err == nil && exists {
+		err = ipt.Delete(table, chain, rulespec...)
+	}
+	return err
+}
+
 // List rules in specified table/chain
 func (ipt *IPTables) List(table, chain string) ([]string, error) {
 	args := []string{"-t", table, "-S", chain}
@@ -195,6 +254,21 @@ func (ipt *IPTables) ListChains(table string) ([]string, error) {
 		}
 	}
 	return chains, nil
+}
+
+// '-S' is fine with non existing rule index as long as the chain exists
+// therefore pass index 1 to reduce overhead for large chains
+func (ipt *IPTables) ChainExists(table, chain string) (bool, error) {
+	err := ipt.run("-t", table, "-S", chain, "1")
+	eerr, eok := err.(*Error)
+	switch {
+	case err == nil:
+		return true, nil
+	case eok && eerr.ExitStatus() == 1:
+		return false, nil
+	default:
+		return false, err
+	}
 }
 
 // Stats lists rules including the byte and packet counts
@@ -263,6 +337,63 @@ func (ipt *IPTables) Stats(table, chain string) ([][]string, error) {
 	return rows, nil
 }
 
+// ParseStat parses a single statistic row into a Stat struct. The input should
+// be a string slice that is returned from calling the Stat method.
+func (ipt *IPTables) ParseStat(stat []string) (parsed Stat, err error) {
+	// For forward-compatibility, expect at least 10 fields in the stat
+	if len(stat) < 10 {
+		return parsed, fmt.Errorf("stat contained fewer fields than expected")
+	}
+
+	// Convert the fields that are not plain strings
+	parsed.Packets, err = strconv.ParseUint(stat[0], 0, 64)
+	if err != nil {
+		return parsed, fmt.Errorf(err.Error(), "could not parse packets")
+	}
+	parsed.Bytes, err = strconv.ParseUint(stat[1], 0, 64)
+	if err != nil {
+		return parsed, fmt.Errorf(err.Error(), "could not parse bytes")
+	}
+	_, parsed.Source, err = net.ParseCIDR(stat[7])
+	if err != nil {
+		return parsed, fmt.Errorf(err.Error(), "could not parse source")
+	}
+	_, parsed.Destination, err = net.ParseCIDR(stat[8])
+	if err != nil {
+		return parsed, fmt.Errorf(err.Error(), "could not parse destination")
+	}
+
+	// Put the fields that are strings
+	parsed.Target = stat[2]
+	parsed.Protocol = stat[3]
+	parsed.Opt = stat[4]
+	parsed.Input = stat[5]
+	parsed.Output = stat[6]
+	parsed.Options = stat[9]
+
+	return parsed, nil
+}
+
+// StructuredStats returns statistics as structured data which may be further
+// parsed and marshaled.
+func (ipt *IPTables) StructuredStats(table, chain string) ([]Stat, error) {
+	rawStats, err := ipt.Stats(table, chain)
+	if err != nil {
+		return nil, err
+	}
+
+	structStats := []Stat{}
+	for _, rawStat := range rawStats {
+		stat, err := ipt.ParseStat(rawStat)
+		if err != nil {
+			return nil, err
+		}
+		structStats = append(structStats, stat)
+	}
+
+	return structStats, nil
+}
+
 func (ipt *IPTables) executeList(args []string) ([]string, error) {
 	var stdout bytes.Buffer
 	if err := ipt.runWithOutput(args, &stdout); err != nil {
@@ -274,17 +405,6 @@ func (ipt *IPTables) executeList(args []string) ([]string, error) {
 	// strip trailing newline
 	if len(rules) > 0 && rules[len(rules)-1] == "" {
 		rules = rules[:len(rules)-1]
-	}
-
-	// nftables mode doesn't return an error code when listing a non-existent
-	// chain. Patch that up.
-	if len(rules) == 0 && ipt.mode == "nf_tables" {
-		v := 1
-		return nil, &Error{
-			cmd:        exec.Cmd{Args: args},
-			msg:        "iptables: No chain/target/match by that name.",
-			exitStatus: &v,
-		}
 	}
 
 	for i, rule := range rules {
@@ -300,17 +420,12 @@ func (ipt *IPTables) NewChain(table, chain string) error {
 	return ipt.run("-t", table, "-N", chain)
 }
 
+const existsErr = 1
+
 // ClearChain flushed (deletes all rules) in the specified table/chain.
 // If the chain does not exist, a new one will be created
 func (ipt *IPTables) ClearChain(table, chain string) error {
 	err := ipt.NewChain(table, chain)
-
-	// the exit code for "this table already exists" is different for
-	// different iptables modes
-	existsErr := 1
-	if ipt.mode == "nf_tables" {
-		existsErr = 1
-	}
 
 	eerr, eok := err.(*Error)
 	switch {
@@ -333,6 +448,26 @@ func (ipt *IPTables) RenameChain(table, oldChain, newChain string) error {
 // The chain must be empty
 func (ipt *IPTables) DeleteChain(table, chain string) error {
 	return ipt.run("-t", table, "-X", chain)
+}
+
+func (ipt *IPTables) ClearAndDeleteChain(table, chain string) error {
+	exists, err := ipt.ChainExists(table, chain)
+	if err != nil || !exists {
+		return err
+	}
+	err = ipt.run("-t", table, "-F", chain)
+	if err == nil {
+		err = ipt.run("-t", table, "-X", chain)
+	}
+	return err
+}
+
+func (ipt *IPTables) ClearAll() error {
+	return ipt.run("-F")
+}
+
+func (ipt *IPTables) DeleteAll() error {
+	return ipt.run("-X")
 }
 
 // ChangePolicy changes policy on chain to target
@@ -362,6 +497,9 @@ func (ipt *IPTables) runWithOutput(args []string, stdout io.Writer) error {
 	args = append([]string{ipt.path}, args...)
 	if ipt.hasWait {
 		args = append(args, "--wait")
+		if ipt.timeout != 0 && ipt.waitSupportSecond {
+			args = append(args, strconv.Itoa(ipt.timeout))
+		}
 	} else {
 		fmu, err := newXtablesFileLock()
 		if err != nil {
@@ -369,6 +507,7 @@ func (ipt *IPTables) runWithOutput(args []string, stdout io.Writer) error {
 		}
 		ul, err := fmu.tryLock()
 		if err != nil {
+			syscall.Close(fmu.fd)
 			return err
 		}
 		defer ul.Unlock()
@@ -404,8 +543,8 @@ func getIptablesCommand(proto Protocol) string {
 }
 
 // Checks if iptables has the "-C" and "--wait" flag
-func getIptablesCommandSupport(v1 int, v2 int, v3 int) (bool, bool, bool) {
-	return iptablesHasCheckCommand(v1, v2, v3), iptablesHasWaitCommand(v1, v2, v3), iptablesHasRandomFully(v1, v2, v3)
+func getIptablesCommandSupport(v1 int, v2 int, v3 int) (bool, bool, bool, bool) {
+	return iptablesHasCheckCommand(v1, v2, v3), iptablesHasWaitCommand(v1, v2, v3), iptablesWaitSupportSecond(v1, v2, v3), iptablesHasRandomFully(v1, v2, v3)
 }
 
 // getIptablesVersion returns the first three components of the iptables version
@@ -475,6 +614,17 @@ func iptablesHasWaitCommand(v1 int, v2 int, v3 int) bool {
 		return true
 	}
 	if v1 == 1 && v2 == 4 && v3 >= 20 {
+		return true
+	}
+	return false
+}
+
+//Checks if an iptablse version is after 1.6.0, when --wait support second
+func iptablesWaitSupportSecond(v1 int, v2 int, v3 int) bool {
+	if v1 > 1 {
+		return true
+	}
+	if v1 == 1 && v2 >= 6 {
 		return true
 	}
 	return false

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -33,8 +33,8 @@ github.com/containernetworking/cni/pkg/types/020
 github.com/containernetworking/cni/pkg/types/current
 github.com/containernetworking/cni/pkg/utils
 github.com/containernetworking/cni/pkg/version
-# github.com/coreos/go-iptables v0.4.0
-## explicit
+# github.com/coreos/go-iptables v0.6.0
+## explicit; go 1.16
 github.com/coreos/go-iptables/iptables
 # github.com/davecgh/go-spew v1.1.1
 ## explicit


### PR DESCRIPTION
*Description of changes:*

- We found a bug that makes DEL not idempotent so customer will get an error if trying to delete the same Ingress/Egress chain again. Added check for existence before deleting. Also added a test for that.

- e2e test was broken by the cni version upgrade. By supplying requested variables, tests are working again. (I did not change e2e tests in other plugins but they are broken as well)

- Fixed a bug in adding new rules which will make the iptables command look like this: `/sbin/iptables -t nat -A APPMESH_INGRESS -p tcp -m multiport --dports ,,,,,,,,,,,,,,,5000,5001 -j REDIRECT --to-port 8000 --wait]: exit status 2: iptables v1.8.4 (legacy): invalid port/service '' specified.` This bug was introduced in #77.

- Fixed e2e test for serviceconnect plugin

- Updated go-iptable module version from 0.4.0 to 0.6.0 to fix an existing bug for different iptables version.
 
- Added an e2e test for multiports scenario

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
