### PR TITLE
Block IMDS access over IPv6 when BlockIMDS is set

### DIFF
--- a/network/imds/imds_linux.go
+++ b/network/imds/imds_linux.go
@@ -25,23 +25,23 @@ import (
 
 // BlockInstanceMetadataEndpoint adds a blackhole rule for IMDS endpoint.
 func BlockInstanceMetadataEndpoint() error {
-	log.Infof("Adding route to block instance metadata endpoint %s", vpc.InstanceMetadataEndpoint)
-	_, imdsNetwork, err := net.ParseCIDR(vpc.InstanceMetadataEndpoint)
-	if err != nil {
-		// This should never happen because we always expect
-		// 169.254.169.254/32 to be parsed without any errors.
-		log.Errorf("Unable to parse instance metadata endpoint %s", vpc.InstanceMetadataEndpoint)
-		return err
-	}
+	for _, ep := range vpc.InstanceMetadataEndpoints {
+		log.Infof("Adding route to block instance metadata endpoint %s", ep)
+		_, imdsNetwork, err := net.ParseCIDR(ep)
+		if err != nil {
+			// This should never happen as these IP addresses are hardcoded.
+			log.Errorf("Unable to parse instance metadata endpoint %s", ep)
+			return err
+		}
 
-	err = netlink.RouteAdd(&netlink.Route{
-		Dst:  imdsNetwork,
-		Type: syscall.RTN_BLACKHOLE,
-	})
-	if err != nil {
-		log.Errorf("Unable to add route to block instance metadata: %v", err)
-		return err
+		err = netlink.RouteAdd(&netlink.Route{
+			Dst:  imdsNetwork,
+			Type: syscall.RTN_BLACKHOLE,
+		})
+		if err != nil {
+			log.Errorf("Unable to add route to block instance metadata: %v", err)
+			return err
+		}
 	}
-
 	return nil
 }

--- a/network/vpc/vpc.go
+++ b/network/vpc/vpc.go
@@ -14,9 +14,11 @@
 package vpc
 
 const (
-	// InstanceMetadataEndpoint is EC2's instance metadata endpoint.
-	InstanceMetadataEndpoint = "169.254.169.254/32"
-
 	// JumboFrameMTU is the VPC jumbo Ethernet frame Maximum Transmission Unit size in bytes.
 	JumboFrameMTU = 9001
+)
+
+var (
+	// InstanceMetadataEndpoints is the list of EC2 instance metadata endpoints.
+	InstanceMetadataEndpoints = []string{"169.254.169.254/32", "fd00:ec2::254/128"}
 )


### PR DESCRIPTION
*Description of changes:*

When the CNI plugins in this repo were implemented, IMDS was accessible only over IPv4. EC2 networking team 
introduced IMDS access over IPv6 last year. This change extends the BlockIMDS functionality to cover IPV6.

*Testing:*
`make unit-test`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
