### PR TITLE
Update Windows BlockIMDS to use IPv4 endpoint only

### DIFF
--- a/network/imds/imds_windows.go
+++ b/network/imds/imds_windows.go
@@ -32,8 +32,11 @@ const (
 )
 
 // BlockInstanceMetadataEndpoint blocks the IMDS endpoint for Windows by creating HNS ACLs.
+// Currently we block IMDS endpoint over IPv4 only. We will want to block the IPv6 endpoint as
+// well once HNS ACLs support IPv6.
 func BlockInstanceMetadataEndpoint(hnsEndpoint *hcsshim.HNSEndpoint) error {
-	log.Infof("Adding ACLs to block instance metadata endpoint %s", vpc.InstanceMetadataEndpoint)
+	log.Infof("Adding ACLs to block instance metadata endpoint %s",
+		vpc.InstanceMetadataEndpointIPv4)
 	// Create an ACL policy to block traffic to instance metadata endpoint.
 	err := addEndpointPolicy(
 		hnsEndpoint,
@@ -41,7 +44,7 @@ func BlockInstanceMetadataEndpoint(hnsEndpoint *hcsshim.HNSEndpoint) error {
 			Type:            hcsshim.ACL,
 			Action:          hcsshim.Block,
 			Direction:       hcsshim.Out,
-			RemoteAddresses: vpc.InstanceMetadataEndpoint,
+			RemoteAddresses: vpc.InstanceMetadataEndpointIPv4,
 			Protocol:        hnsAclPolicyAllProtocols,
 			Priority:        hnsAclPolicyHighPriority,
 		})

--- a/network/vpc/vpc.go
+++ b/network/vpc/vpc.go
@@ -16,9 +16,11 @@ package vpc
 const (
 	// JumboFrameMTU is the VPC jumbo Ethernet frame Maximum Transmission Unit size in bytes.
 	JumboFrameMTU = 9001
+	// InstanceMetadataEndpointIPv4 represents the IMDS endpoint over IPv4.
+	InstanceMetadataEndpointIPv4 = "169.254.169.254/32"
 )
 
 var (
 	// InstanceMetadataEndpoints is the list of EC2 instance metadata endpoints.
-	InstanceMetadataEndpoints = []string{"169.254.169.254/32", "fd00:ec2::254/128"}
+	InstanceMetadataEndpoints = []string{InstanceMetadataEndpointIPv4, "fd00:ec2::254/128"}
 )


### PR DESCRIPTION
*Issue #, if available:*
This is a follow-up for https://github.com/aws/amazon-vpc-cni-plugins/pull/84. We introduced IMDS IPv6 endpoint in the previous PR, however for Windows we will keep blocking IPv4 endpoint only until we can block IPv6 endpoint using HNS.

*Description of changes:*
Update Windows BlockIMDS to use IPv4 endpoint only

`GOOS=windows make vpc-eni ` and `GOOS=windows make vpc-shared-eni` both built successfully.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
