### PR TITLE
Fix end to end tests and some other improvements

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,8 +2,6 @@ name: Build
 
 on:
   push:
-    branches:
-      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,8 +8,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: setup Go
+      - name: checkout code
+        uses: actions/checkout@v3
+      - name: setup go
         uses: actions/setup-go@v3
         with:
           go-version: '1.19.x'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,6 +21,12 @@ jobs:
         run: |
           ip link show
           sudo ip link add eth1 type dummy
+          sudo ip link set dev eth1 mtu 9001
+          sudo ip link set dev eth1 up
+          ip link show
+          sudo ip link add eth2 type dummy
+          sudo ip link set dev eth2 mtu 9001
+          sudo ip link set dev eth2 up
           ip link show
       - name: test
         run: make e2e-test

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -20,4 +20,4 @@ jobs:
         if: failure()
         with:
           name: testlogs
-          path: /tmp/*-e2etests*/*
+          path: /tmp/*-e2eTests-*/*

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,8 +2,6 @@ name: e2e tests
 
 on:
   push:
-    branches:
-      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+env:
+  ECS_PRESERVE_E2E_TEST_LOGS: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -18,6 +18,7 @@ jobs:
         with:
           go-version: '1.19.x'
       - name: pretest
+        # see ../../TESTING.md for more information on this step
         run: |
           ip link show
           sudo ip link add eth1 type dummy

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,3 +15,9 @@ jobs:
           go-version: '1.19.x'
       - name: test
         run: make e2e-test
+      - name: upload failed test artifacts
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: testlogs
+          path: tmp/*-e2etests*/**

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,7 +8,7 @@ env:
   ECS_PRESERVE_E2E_TEST_LOGS: true
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -20,4 +20,4 @@ jobs:
         if: failure()
         with:
           name: testlogs
-          path: tmp/*-e2etests*/**
+          path: /tmp/*-e2etests*/*

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -18,7 +18,10 @@ jobs:
         with:
           go-version: '1.19.x'
       - name: pretest
-        run: sudo ip link add eth1 type dummy
+        run: |
+          ip link show
+          sudo ip link add eth1 type dummy
+          ip link show
       - name: test
         run: make e2e-test
       - name: upload failed test artifacts

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -11,11 +11,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: setup Go
+      - name: checkout code
+        uses: actions/checkout@v3
+      - name: setup go
         uses: actions/setup-go@v3
         with:
           go-version: '1.19.x'
+      - name: pretest
+        run: sudo ip link add eth1 type dummy
       - name: test
         run: make e2e-test
       - name: upload failed test artifacts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,29 +1,28 @@
 # Contributing Guidelines
 
-Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional 
+Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional
 documentation, we greatly value feedback and contributions from our community.
 
-Please read through this document before submitting any issues or pull requests to ensure we have all the necessary 
+Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
 information to effectively respond to your bug report or contribution.
-
 
 ## Reporting Bugs/Feature Requests
 
 We welcome you to use the GitHub issue tracker to report bugs or suggest features.
 
-When filing an issue, please check [existing open](https://github.com/aws/amazon-vpc-cni-plugins/issues), or [recently closed](https://github.com/aws/amazon-vpc-cni-plugins/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already 
+When filing an issue, please check [existing open](https://github.com/aws/amazon-vpc-cni-plugins/issues), or [recently closed](https://github.com/aws/amazon-vpc-cni-plugins/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already
 reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
 
-* A reproducible test case or series of steps
-* The version of our code being used
-* Any modifications you've made relevant to the bug
-* Anything unusual about your environment or deployment
-
+- A reproducible test case or series of steps
+- The version of our code being used
+- Any modifications you've made relevant to the bug
+- Anything unusual about your environment or deployment
 
 ## Contributing via Pull Requests
+
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the *master* branch.
+1. You are working against the latest source on the _master_ branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 
@@ -31,28 +30,27 @@ To send us a pull request, please:
 
 1. Fork the repository.
 2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
-3. Ensure local tests pass.
+3. Ensure local tests pass. Check out [our testing guide](./TESTING.md) for setup.
 4. Commit to your fork using clear commit messages.
 5. Send us a pull request, answering any default questions in the pull request interface.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
-GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and 
+GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
-
 ## Finding contributions to work on
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/aws/amazon-vpc-cni-plugins/labels/help%20wanted) issues is a great place to start. 
 
+Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/aws/amazon-vpc-cni-plugins/labels/help%20wanted) issues is a great place to start.
 
 ## Code of Conduct
-This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct). 
-For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact 
+
+This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
+For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
 opensource-codeofconduct@amazon.com with any additional questions or comments.
 
-
 ## Security issue notifications
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
 
+If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ VPC CNI plugins for Amazon ECS and Amazon EKS.
 
 ## Security disclosures
 
-If you think you’ve found a potential security issue, please do not post it in the Issues.  Instead, please follow the instructions [here](https://aws.amazon.com/security/vulnerability-reporting/) or [email AWS security directly](mailto:aws-security@amazon.com).
+If you think you’ve found a potential security issue, please do not post it in the Issues. Instead, please follow the instructions [here](https://aws.amazon.com/security/vulnerability-reporting/) or [email AWS security directly](mailto:aws-security@amazon.com).
 
 ## License
 
-This library is licensed under the Apache 2.0 License. 
+This library is licensed under the Apache 2.0 License.

--- a/TESTING.md
+++ b/TESTING.md
@@ -15,7 +15,15 @@ There is some tooling that needs to be in place for the tests to be able to run,
 
 For the end to end tests, a successful build is also required. A build can be triggered by running `make build`.
 
-The tests commonly reference a network interface by the name of `eth1`. If the tests are being run in an environment that does not include an `eth1` interface, a dummy `eth1` interface can be created by running `ip link add eth1 type dummy`. Elevated privilege (`sudo`) might be necessary to run the command. The existing interfaces can be checked at any time using `ip link show`.
+## Networking setup
+
+The tests commonly reference network interfaces called `eth1` and `eth2`. It is encouraged that tests be run in an environment where `eth1` and `eth2` do not exist and are not being used for any critical workloads because the state of these interfaces will be modified by the tests.
+
+Accordingly, a dummy `eth1` interface can be created by running `ip link add eth1 type dummy`. Likewise for the `eth2` interface. Elevated privilege (`sudo`) might be necessary to run the commands. The existing interfaces can be checked at any time using `ip link show` and the dummy interfaces can be cleaned up by running `ip link delete eth1` and `ip link delete eth2`. The cleanup commands might also require elevated privileges.
+
+The pretest step in the [e2e.yaml](.github/workflows/e2e.yaml) does this exactly, brings up (enables) the interface, and also (optionally) sets the [MTU](https://en.wikipedia.org/wiki/Maximum_transmission_unit) to match the MTU value that we commonly set for AWS networking interfaces.
+
+This does mean that the tests will only run on Linux distros that support creating dummy interfaces via the [`ip`](https://man7.org/linux/man-pages/man8/ip.8.html) command.
 
 ## Running
 
@@ -34,7 +42,11 @@ There are also some specific Make targets included to help with more directed te
 
 ## Debugging
 
-If you're running VS Code, here is a sample `launch.json` that can help set up debugging for the tests. Something to note is that since these tests run with elevated privileges, it is always a good idea to not stop a test in the middle of execution because it might leave behind resources that need cleaned up.
+If you're running VS Code, here is a sample `launch.json` that can help set up debugging for the tests. This uses the [`vscode-go`](https://github.com/golang/vscode-go) extension.
+
+Something to note is that since these tests run with elevated privileges, it is always a good idea to not stop a test in the middle of execution because it might leave behind resources and/or configuration that needs cleaned up.
+
+The computed CNI path input is a prompt from VSCode that gives users the chance to modify the path where all the CNI plugin binaries reside. By default, it is `<workspace_folder>/build/<os>_<arch>`. The default build path assumes linux on x86_64 architecture but it can be changed via this prompt.
 
 ```json
 {

--- a/TESTING.md
+++ b/TESTING.md
@@ -8,10 +8,10 @@ There are two different kinds of tests that are included with this repository, u
 
 There is some tooling that needs to be in place for the tests to be able to run, the basics are listed below
 
-- Git - you can install either the `build-essentials` meta package on Debian based distros or the package group called `'Development Tools'` on RHEL based distros and that will get you `git`. Otherwise, you can install Git separately as well.
+- Git - you can install either the `build-essential` meta package on Debian based distros or the package group called `'Development Tools'` on RHEL based distros and that will get you `git`. Otherwise, you can install Git separately as well.
 - Make - the above meta package/package group will also include `make` but it can also be installed separately.
 - Go - go can be installed from the golang website; the tests are confirmed working on Go version 1.19
-- `iptables` - in case the tests are being run in a minimal environment, `iptables` can be obtained from the default package manager for the distro; it might also come installed already on the system
+- `iptables` - in case the tests are being run in a minimal environment, `iptables` can be obtained from the default package manager for the distro; it is likely that it is already installed on the system
 
 For the end to end tests, a successful build is also required. A build can be triggered by running `make build`.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,31 @@
+# amazon-vpc-cni-plugins
+
+## Included tests
+
+There are two different kinds of tests that are included with this repository, unit tests and end to end tests.
+
+## Basic setup
+
+There is some tooling that needs to be in place for the tests to be able to run, the basics are listed below
+
+- Git - you can install either the `build-essentials` meta package on Debian based distros or the package group called `'Development Tools'` on RHEL based distros and that will get you `git`. Otherwise, you can install Git separately as well.
+- Make - the above meta package/package group will also include `make` but it can also be installed separately.
+- Go - go can be installed from the golang website; the tests are confirmed working on Go version 1.19
+- `iptables` - in case the tests are being run in a minimal environment, `iptables` can be obtained from the default package manager for the distro; it might also come installed already on the system
+
+For the end to end tests, a successful build is also required. A build can be triggered by running `make build`.
+
+## Running
+
+The unit tests can be run using `make unit-test` and the end to end tests can be run using `make e2e-test`.
+
+There are also some specific Make targets included to help with more directed testing. These are included in the table below
+
+| Target                         | Description                                                   |
+| ------------------------------ | ------------------------------------------------------------- |
+| `appmesh-unit-test`            | Run only the `aws-appmesh` plugin unit tests                  |
+| `ecs-serviceconnect-unit-test` | Run only the `ecs-serviceconnect` plugin unit tests           |
+| `vpc-branch-eni-e2e-tests`     | Run only the the `vpc-branch-eni` plugin end to end tests     |
+| `vpc-tunnel-e2e-tests`         | Run only the the `vpc-tunnel` plugin end to end tests         |
+| `appmesh-e2e-tests`            | Run only the the `aws-appmesh` plugin end to end tests        |
+| `ecs-serviceconnect-e2e-test`  | Run only the the `ecs-serviceconnect` plugin end to end tests |

--- a/TESTING.md
+++ b/TESTING.md
@@ -15,6 +15,8 @@ There is some tooling that needs to be in place for the tests to be able to run,
 
 For the end to end tests, a successful build is also required. A build can be triggered by running `make build`.
 
+The tests commonly reference a network interface by the name of `eth1`. If the tests are being run in an environment that does not include an `eth1` interface, a dummy `eth1` interface can be created by running `ip link add eth1 type dummy`. Elevated privilege (`sudo`) might be necessary to run the command. The existing interfaces can be checked at any time using `ip link show`.
+
 ## Running
 
 The unit tests can be run using `make unit-test` and the end to end tests can be run using `make e2e-test`.

--- a/TESTING.md
+++ b/TESTING.md
@@ -29,3 +29,39 @@ There are also some specific Make targets included to help with more directed te
 | `vpc-tunnel-e2e-tests`         | Run only the the `vpc-tunnel` plugin end to end tests         |
 | `appmesh-e2e-tests`            | Run only the the `aws-appmesh` plugin end to end tests        |
 | `ecs-serviceconnect-e2e-test`  | Run only the the `ecs-serviceconnect` plugin end to end tests |
+
+## Debugging
+
+If you're running VS Code, here is a sample `launch.json` that can help set up debugging for the tests. Something to note is that since these tests run with elevated privileges, it is always a good idea to not stop a test in the middle of execution because it might leave behind resources that need cleaned up.
+
+```json
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug e2e test",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${fileDirname}",
+      "asRoot": true,
+      "console": "integratedTerminal",
+      "buildFlags": "-tags=e2e_test",
+      "env": {
+        "CNI_PATH": "${input:computedCniPath}"
+      }
+    }
+  ],
+  "inputs": [
+    {
+      "id": "computedCniPath",
+      "description": "Optional, the path to the CNI plugin build in case the OS or the arch are different.",
+      "type": "promptString",
+      "default": "${workspaceFolder}${pathSeparator}build${pathSeparator}linux_amd64"
+    }
+  ]
+}
+```

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/cihub/seelog v0.0.0-20151216151435-d2c6e5aa9fbf h1:XI2tOTCBqEnMyN2j1y
 github.com/cihub/seelog v0.0.0-20151216151435-d2c6e5aa9fbf/go.mod h1:9d6lWj8KzO/fd/NrVaLscBKmPigpZpn5YawRPw+e3Yo=
 github.com/containernetworking/cni v0.8.1 h1:7zpDnQ3T3s4ucOuJ/ZCLrYBxzkg0AELFfII3Epo9TmI=
 github.com/containernetworking/cni v0.8.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
-github.com/coreos/go-iptables v0.4.0 h1:wh4UbVs8DhLUbpyq97GLJDKrQMjEDD63T1xE4CrsKzQ=
-github.com/coreos/go-iptables v0.4.0/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
 github.com/coreos/go-iptables v0.6.0 h1:is9qnZMPYjLd8LYqmm/qlE+wwEgJIkTYdhV3rfZo4jk=
 github.com/coreos/go-iptables v0.6.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/plugins/aws-appmesh/e2eTests/e2e_test.go
+++ b/plugins/aws-appmesh/e2eTests/e2e_test.go
@@ -117,6 +117,7 @@ func initTest(t *testing.T) {
 
 	// Create a directory for storing test logs.
 	testLogDir, err := os.MkdirTemp("", "aws-appmesh-cni-e2eTests-test-")
+	err = os.Chmod(testLogDir, "0755")
 	require.NoError(t, err, "Unable to create directory for storing test logs")
 
 	// Configure the env var to use the test logs directory.

--- a/plugins/aws-appmesh/e2eTests/e2e_test.go
+++ b/plugins/aws-appmesh/e2eTests/e2e_test.go
@@ -51,7 +51,7 @@ const (
 	egressIgnoredIPv6Addresses = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
 	containerID                = "contain-er"
 	ifName                     = "test"
-	nsName                     = "testNS"
+	nsName                     = "awsAppmeshTestNS"
 )
 
 type testMeta struct {

--- a/plugins/aws-appmesh/e2eTests/e2e_test.go
+++ b/plugins/aws-appmesh/e2eTests/e2e_test.go
@@ -117,7 +117,7 @@ func initTest(t *testing.T) {
 
 	// Create a directory for storing test logs.
 	testLogDir, err := os.MkdirTemp("", "aws-appmesh-cni-e2eTests-test-")
-	err = os.Chmod(testLogDir, "0755")
+	err = os.Chmod(testLogDir, 0755)
 	require.NoError(t, err, "Unable to create directory for storing test logs")
 
 	// Configure the env var to use the test logs directory.
@@ -240,7 +240,7 @@ func testValid(t *testing.T, meta testMeta) {
 // loadTestData loads test cases in json form.
 func loadTestData(t *testing.T, name string) []byte {
 	path := filepath.Join("testdata", name+".json")
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/aws-appmesh/e2eTests/e2e_test.go
+++ b/plugins/aws-appmesh/e2eTests/e2e_test.go
@@ -19,7 +19,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -117,7 +116,7 @@ func initTest(t *testing.T) {
 	require.NoError(t, err, "Unable to find aws-appmesh plugin in path")
 
 	// Create a directory for storing test logs.
-	testLogDir, err := ioutil.TempDir("", "aws-appmesh-cni-e2eTests-test-")
+	testLogDir, err := os.MkdirTemp("", "aws-appmesh-cni-e2eTests-test-")
 	require.NoError(t, err, "Unable to create directory for storing test logs")
 
 	// Configure the env var to use the test logs directory.

--- a/plugins/ecs-serviceconnect/e2eTests/e2e_test.go
+++ b/plugins/ecs-serviceconnect/e2eTests/e2e_test.go
@@ -128,7 +128,7 @@ func loadTestData(t *testing.T, name string) []byte {
 		t.Fatal(err)
 	}
 	path := filepath.Join(filepath.Dir(wd), "testdata", name+".json")
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -467,7 +467,7 @@ func getEnvOrDefault(name string, fallback string) string {
 func setupLogs(t *testing.T, testCase string) (string, bool) {
 	// Create a directory for storing test logs.
 	testLogDir, err := os.MkdirTemp("", pluginName+"-cni-e2eTests-test")
-	err = os.Chmod(testLogDir, "0755")
+	err = os.Chmod(testLogDir, 0755)
 	require.NoError(t, err, "Unable to create directory for storing test logs")
 
 	// Configure the env var to use the test logs directory.

--- a/plugins/ecs-serviceconnect/e2eTests/e2e_test.go
+++ b/plugins/ecs-serviceconnect/e2eTests/e2e_test.go
@@ -19,7 +19,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -467,7 +466,7 @@ func getEnvOrDefault(name string, fallback string) string {
 // and a bool that represents whether to preserve logfiles after execution.
 func setupLogs(t *testing.T, testCase string) (string, bool) {
 	// Create a directory for storing test logs.
-	testLogDir, err := ioutil.TempDir("", pluginName+"-cni-e2eTests-test")
+	testLogDir, err := os.MkdirTemp("", pluginName+"-cni-e2eTests-test")
 	require.NoError(t, err, "Unable to create directory for storing test logs")
 
 	// Configure the env var to use the test logs directory.

--- a/plugins/ecs-serviceconnect/e2eTests/e2e_test.go
+++ b/plugins/ecs-serviceconnect/e2eTests/e2e_test.go
@@ -467,6 +467,7 @@ func getEnvOrDefault(name string, fallback string) string {
 func setupLogs(t *testing.T, testCase string) (string, bool) {
 	// Create a directory for storing test logs.
 	testLogDir, err := os.MkdirTemp("", pluginName+"-cni-e2eTests-test")
+	err = os.Chmod(testLogDir, "0755")
 	require.NoError(t, err, "Unable to create directory for storing test logs")
 
 	// Configure the env var to use the test logs directory.

--- a/plugins/vpc-branch-eni/e2eTests/e2e_test.go
+++ b/plugins/vpc-branch-eni/e2eTests/e2e_test.go
@@ -98,7 +98,7 @@ func testAddDel(t *testing.T, netConfJsonFmt string, validateAfterAddFunc, valid
 
 	// Create a directory for storing test logs.
 	testLogDir, err := os.MkdirTemp("", "vpc-branch-eni-cni-e2eTests-test-")
-	err = os.Chmod(testLogDir, "0755")
+	err = os.Chmod(testLogDir, 0755)
 	require.NoError(t, err, "Unable to create directory for storing test logs")
 
 	// Configure the env var to use the test logs directory.

--- a/plugins/vpc-branch-eni/e2eTests/e2e_test.go
+++ b/plugins/vpc-branch-eni/e2eTests/e2e_test.go
@@ -19,7 +19,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strconv"
@@ -98,7 +97,7 @@ func testAddDel(t *testing.T, netConfJsonFmt string, validateAfterAddFunc, valid
 	require.NoError(t, err, "Unable to find vpc-branch-eni plugin in path")
 
 	// Create a directory for storing test logs.
-	testLogDir, err := ioutil.TempDir("", "vpc-branch-eni-cni-e2eTests-test-")
+	testLogDir, err := os.MkdirTemp("", "vpc-branch-eni-cni-e2eTests-test-")
 	require.NoError(t, err, "Unable to create directory for storing test logs")
 
 	// Configure the env var to use the test logs directory.

--- a/plugins/vpc-branch-eni/e2eTests/e2e_test.go
+++ b/plugins/vpc-branch-eni/e2eTests/e2e_test.go
@@ -73,9 +73,9 @@ const (
 `
 )
 
-func TestAddDelBlockIMDS(t *testing.T) {
-	testAddDel(t, netConfJsonFmtBlockIMDS, validateAfterAddBlockIMDS, validateAfterDel)
-}
+// func TestAddDelBlockIMDS(t *testing.T) {
+// 	testAddDel(t, netConfJsonFmtBlockIMDS, validateAfterAddBlockIMDS, validateAfterDel)
+// }
 
 func TestAddDel(t *testing.T) {
 	var err error

--- a/plugins/vpc-branch-eni/e2eTests/e2e_test.go
+++ b/plugins/vpc-branch-eni/e2eTests/e2e_test.go
@@ -98,6 +98,7 @@ func testAddDel(t *testing.T, netConfJsonFmt string, validateAfterAddFunc, valid
 
 	// Create a directory for storing test logs.
 	testLogDir, err := os.MkdirTemp("", "vpc-branch-eni-cni-e2eTests-test-")
+	err = os.Chmod(testLogDir, "0755")
 	require.NoError(t, err, "Unable to create directory for storing test logs")
 
 	// Configure the env var to use the test logs directory.

--- a/plugins/vpc-branch-eni/e2eTests/e2e_test.go
+++ b/plugins/vpc-branch-eni/e2eTests/e2e_test.go
@@ -36,7 +36,7 @@ import (
 const (
 	containerID        = "container_1"
 	ifName             = "testIf"
-	nsName             = "testNS"
+	nsName             = "vpcBranchEniTestNS"
 	trunkName          = "eth1"
 	branchVlanID       = "101"
 	branchMACAddress   = "02:e1:48:75:86:a4"
@@ -73,9 +73,9 @@ const (
 `
 )
 
-// func TestAddDelBlockIMDS(t *testing.T) {
-// 	testAddDel(t, netConfJsonFmtBlockIMDS, validateAfterAddBlockIMDS, validateAfterDel)
-// }
+func TestAddDelBlockIMDS(t *testing.T) {
+	testAddDel(t, netConfJsonFmtBlockIMDS, validateAfterAddBlockIMDS, validateAfterDel)
+}
 
 func TestAddDel(t *testing.T) {
 	var err error

--- a/plugins/vpc-tunnel/e2eTests/e2e_test.go
+++ b/plugins/vpc-tunnel/e2eTests/e2e_test.go
@@ -19,7 +19,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"testing"
@@ -81,7 +80,7 @@ func testAddDel(t *testing.T, netConfJsonFmt string, validateAfterAddFunc, valid
 	require.NoError(t, err, "Unable to find vpc-tunnel plugin in path")
 
 	// Create a directory for storing test logs.
-	testLogDir, err := ioutil.TempDir("", "vpc-tunnel-cni-e2eTests-test-")
+	testLogDir, err := os.MkdirTemp("", "vpc-tunnel-cni-e2eTests-test-")
 	require.NoError(t, err, "Unable to create directory for storing test logs")
 
 	// Configure the env var to use the test logs directory.

--- a/plugins/vpc-tunnel/e2eTests/e2e_test.go
+++ b/plugins/vpc-tunnel/e2eTests/e2e_test.go
@@ -81,7 +81,7 @@ func testAddDel(t *testing.T, netConfJsonFmt string, validateAfterAddFunc, valid
 
 	// Create a directory for storing test logs.
 	testLogDir, err := os.MkdirTemp("", "vpc-tunnel-cni-e2eTests-test-")
-	err = os.Chmod(testLogDir, "0755")
+	err = os.Chmod(testLogDir, 0755)
 	require.NoError(t, err, "Unable to create directory for storing test logs")
 
 	// Configure the env var to use the test logs directory.

--- a/plugins/vpc-tunnel/e2eTests/e2e_test.go
+++ b/plugins/vpc-tunnel/e2eTests/e2e_test.go
@@ -81,6 +81,7 @@ func testAddDel(t *testing.T, netConfJsonFmt string, validateAfterAddFunc, valid
 
 	// Create a directory for storing test logs.
 	testLogDir, err := os.MkdirTemp("", "vpc-tunnel-cni-e2eTests-test-")
+	err = os.Chmod(testLogDir, "0755")
 	require.NoError(t, err, "Unable to create directory for storing test logs")
 
 	// Configure the env var to use the test logs directory.

--- a/plugins/vpc-tunnel/e2eTests/e2e_test.go
+++ b/plugins/vpc-tunnel/e2eTests/e2e_test.go
@@ -76,6 +76,15 @@ func TestAddDel(t *testing.T) {
 }
 
 func testAddDel(t *testing.T, netConfJsonFmt string, validateAfterAddFunc, validateAfterDelFunc func(*testing.T)) {
+	/*
+		defaultExec reads plugins from the disk and runs them
+		if we ever want to change this behavior, we need to pass in
+		something that implements the invoke.Exec interface.
+	*/
+	var defaultExec = &(invoke.DefaultExec){
+		RawExec: &(invoke.RawExec){Stderr: os.Stderr},
+	}
+
 	// Ensure that the cni plugin exists.
 	pluginPath, err := invoke.FindInPath("vpc-tunnel", []string{os.Getenv("CNI_PATH")})
 	require.NoError(t, err, "Unable to find vpc-tunnel plugin in path")
@@ -125,11 +134,6 @@ func testAddDel(t *testing.T, netConfJsonFmt string, validateAfterAddFunc, valid
 	netConf := []byte(netConfJson)
 
 	// Execute the "ADD" command for the plugin.
-	/*
-		invoke.DefaultExec reads plugins from the disk and runs them
-		if we ever want to change this behavior, we need to pass in
-		something that implements the invoke.Exec interface.
-	*/
 	execInvokeArgs.Command = "ADD"
 	err = invoke.ExecPluginWithoutResult(
 		context.TODO(),
@@ -145,11 +149,6 @@ func testAddDel(t *testing.T, netConfJsonFmt string, validateAfterAddFunc, valid
 	})
 
 	// Execute the "DEL" command for the plugin.
-	/*
-		invoke.DefaultExec reads plugins from the disk and runs them
-		if we ever want to change this behavior, we need to pass in
-		something that implements the invoke.Exec interface.
-	*/
 	execInvokeArgs.Command = "DEL"
 	err = invoke.ExecPluginWithoutResult(
 		context.TODO(),

--- a/plugins/vpc-tunnel/e2eTests/e2e_test.go
+++ b/plugins/vpc-tunnel/e2eTests/e2e_test.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	containerID        = "container_1"
-	nsName             = "testNS"
+	nsName             = "vpcTunnelTestNS"
 	vni                = "CB0CF5"
 	geneveIPv4Address  = "169.254.0.1/31"
 	gatewayIPv4Address = "169.254.0.0"
@@ -46,6 +46,7 @@ const (
 	netConfJsonFmt     = `
 {
 	"type": "vpc-tunnel",
+	"name": "vpc-tunnel-e2e-testnet",
 	"cniVersion":"0.3.0",
 	"destinationIPAddress": "%s",
 	"vni": "%s",

--- a/plugins/vpc-tunnel/e2eTests/e2e_test.go
+++ b/plugins/vpc-tunnel/e2eTests/e2e_test.go
@@ -17,6 +17,7 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -124,11 +125,18 @@ func testAddDel(t *testing.T, netConfJsonFmt string, validateAfterAddFunc, valid
 	netConf := []byte(netConfJson)
 
 	// Execute the "ADD" command for the plugin.
+	/*
+		invoke.DefaultExec reads plugins from the disk and runs them
+		if we ever want to change this behavior, we need to pass in
+		something that implements the invoke.Exec interface.
+	*/
 	execInvokeArgs.Command = "ADD"
 	err = invoke.ExecPluginWithoutResult(
+		context.TODO(),
 		pluginPath,
 		netConf,
-		execInvokeArgs)
+		execInvokeArgs,
+		invoke.DefaultExec)
 	require.NoError(t, err, "Unable to execute ADD command for vpc-tunnel cni plugin")
 
 	targetNS.Run(func() error {
@@ -137,11 +145,18 @@ func testAddDel(t *testing.T, netConfJsonFmt string, validateAfterAddFunc, valid
 	})
 
 	// Execute the "DEL" command for the plugin.
+	/*
+		invoke.DefaultExec reads plugins from the disk and runs them
+		if we ever want to change this behavior, we need to pass in
+		something that implements the invoke.Exec interface.
+	*/
 	execInvokeArgs.Command = "DEL"
 	err = invoke.ExecPluginWithoutResult(
+		context.TODO(),
 		pluginPath,
 		netConf,
-		execInvokeArgs)
+		execInvokeArgs,
+		invoke.DefaultExec)
 	require.NoError(t, err, "Unable to execute DEL command for vpc-tunnel cni plugin")
 
 	targetNS.Run(func() error {

--- a/plugins/vpc-tunnel/e2eTests/e2e_test.go
+++ b/plugins/vpc-tunnel/e2eTests/e2e_test.go
@@ -84,7 +84,7 @@ func testAddDel(t *testing.T, netConfJsonFmt string, validateAfterAddFunc, valid
 	rawExecInstance := invoke.RawExec{
 		stderr: os.Stderr,
 	}
-	defaultExec := &(invoke.DefaultExec){
+	defaultExec := &invoke.DefaultExec{
 		RawExec: &rawExecInstance
 	}
 

--- a/plugins/vpc-tunnel/e2eTests/e2e_test.go
+++ b/plugins/vpc-tunnel/e2eTests/e2e_test.go
@@ -81,8 +81,11 @@ func testAddDel(t *testing.T, netConfJsonFmt string, validateAfterAddFunc, valid
 		if we ever want to change this behavior, we need to pass in
 		something that implements the invoke.Exec interface.
 	*/
-	var defaultExec = &(invoke.DefaultExec){
-		RawExec: &(invoke.RawExec){Stderr: os.Stderr},
+	rawExecInstance := invoke.RawExec{
+		stderr: os.Stderr,
+	}
+	defaultExec := &(invoke.DefaultExec){
+		RawExec: &rawExecInstance
 	}
 
 	// Ensure that the cni plugin exists.

--- a/plugins/vpc-tunnel/e2eTests/e2e_test.go
+++ b/plugins/vpc-tunnel/e2eTests/e2e_test.go
@@ -76,18 +76,6 @@ func TestAddDel(t *testing.T) {
 }
 
 func testAddDel(t *testing.T, netConfJsonFmt string, validateAfterAddFunc, validateAfterDelFunc func(*testing.T)) {
-	/*
-		defaultExec reads plugins from the disk and runs them
-		if we ever want to change this behavior, we need to pass in
-		something that implements the invoke.Exec interface.
-	*/
-	rawExecInstance := invoke.RawExec{
-		stderr: os.Stderr,
-	}
-	defaultExec := &invoke.DefaultExec{
-		RawExec: &rawExecInstance
-	}
-
 	// Ensure that the cni plugin exists.
 	pluginPath, err := invoke.FindInPath("vpc-tunnel", []string{os.Getenv("CNI_PATH")})
 	require.NoError(t, err, "Unable to find vpc-tunnel plugin in path")
@@ -139,11 +127,11 @@ func testAddDel(t *testing.T, netConfJsonFmt string, validateAfterAddFunc, valid
 	// Execute the "ADD" command for the plugin.
 	execInvokeArgs.Command = "ADD"
 	err = invoke.ExecPluginWithoutResult(
-		context.TODO(),
+		context.Background(),
 		pluginPath,
 		netConf,
 		execInvokeArgs,
-		invoke.DefaultExec)
+		nil)
 	require.NoError(t, err, "Unable to execute ADD command for vpc-tunnel cni plugin")
 
 	targetNS.Run(func() error {
@@ -154,11 +142,11 @@ func testAddDel(t *testing.T, netConfJsonFmt string, validateAfterAddFunc, valid
 	// Execute the "DEL" command for the plugin.
 	execInvokeArgs.Command = "DEL"
 	err = invoke.ExecPluginWithoutResult(
-		context.TODO(),
+		context.Background(),
 		pluginPath,
 		netConf,
 		execInvokeArgs,
-		invoke.DefaultExec)
+		nil)
 	require.NoError(t, err, "Unable to execute DEL command for vpc-tunnel cni plugin")
 
 	targetNS.Run(func() error {


### PR DESCRIPTION
*Description of changes:*
- added a log collector workflow that will pull failed CNI plugin tests log and attach them as artifacts
- added a `TESTING.md` file that goes over some of the testing setup
- migrated `ioutil` to `os` calls
- changed all of the tests to have unique network namespaces
- updated vpc-tunnel test to pass the right arguments to exec
- added the right required setup (creating `eth1` and `eth2` dummy links) to the github workflow
- use a different set of inputs for the `TestAddDelBlockIMDS` test and the `TestAddDel` test
- added a template builder and fields map to make the vpc-branch-eni tests read a little better


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
