### PR TITLE
[vpc-bridge] Support host port mapping for Windows

### DIFF
--- a/network/vpc/port.go
+++ b/network/vpc/port.go
@@ -19,6 +19,13 @@ import (
 	"strings"
 )
 
+// PortMapping contains the container port to host port mapping information.
+type PortMapping struct {
+	Protocol      string `json:"protocol"`
+	HostPort      int    `json:"hostPort"`
+	ContainerPort int    `json:"containerPort"`
+}
+
 // ValidatePort checks whether the port only has digits and is within valid port range.
 func ValidatePort(p string) error {
 	port := strings.TrimSpace(p)

--- a/network/vpc/protocol.go
+++ b/network/vpc/protocol.go
@@ -1,0 +1,43 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package vpc
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	// protocolTCP indicates TCP protocol number for port mapping.
+	protocolTCP uint32 = 6
+	// protocolUDP indicates UDP protocol number for port mapping.
+	protocolUDP uint32 = 17
+)
+
+// ProtocolToNumber converts the protocol to it's assigned number.
+// Reference: https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
+func ProtocolToNumber(protocol string) (uint32, error) {
+	var protocolNumber uint32
+	switch strings.ToUpper(protocol) {
+	case "TCP":
+		protocolNumber = protocolTCP
+	case "UDP":
+		protocolNumber = protocolUDP
+	default:
+		// Protocol number 256 is invalid and therefore, returned with the error.
+		return 256, fmt.Errorf("unsupported protocol for portmapping: %s", protocol)
+	}
+
+	return protocolNumber, nil
+}

--- a/network/vpc/protocol_test.go
+++ b/network/vpc/protocol_test.go
@@ -1,0 +1,53 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+//go:build unit_test
+
+package vpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestProtocolToNumberTCP tests the conversion of TCP protocol to number
+// when the protocol is either in upper or lower case.
+func TestProtocolToNumberTCP(t *testing.T) {
+	protocolToTest := []string{"TCP", "tcp"}
+
+	for _, testProtocol := range protocolToTest {
+		actualProtocolNumber, err := ProtocolToNumber(testProtocol)
+		assert.Equal(t, protocolTCP, actualProtocolNumber)
+		assert.NoError(t, err)
+	}
+}
+
+// TestProtocolToNumberUDP tests the conversion of UDP protocol to number
+// when the protocol is either in upper or lower case.
+func TestProtocolToNumberUDP(t *testing.T) {
+	protocolToTest := []string{"UDP", "udp"}
+
+	for _, testProtocol := range protocolToTest {
+		actualProtocolNumber, err := ProtocolToNumber(testProtocol)
+		assert.Equal(t, protocolUDP, actualProtocolNumber)
+		assert.NoError(t, err)
+	}
+}
+
+// TestProtocolToNumberFailure tests the failure case with invalid protocol.
+func TestProtocolToNumberFailure(t *testing.T) {
+	actualProtocolNumber, err := ProtocolToNumber("ICMP")
+	assert.Equal(t, uint32(256), actualProtocolNumber)
+	assert.Error(t, err)
+}

--- a/plugins/vpc-bridge/config/netconfig.go
+++ b/plugins/vpc-bridge/config/netconfig.go
@@ -38,6 +38,7 @@ type NetConfig struct {
 	BridgeNetNSPath  string
 	IPAddresses      []net.IPNet
 	GatewayIPAddress net.IP
+	PortMappings     []vpc.PortMapping
 	InterfaceType    string
 	TapUserID        int
 	Kubernetes       *KubernetesConfig
@@ -46,6 +47,9 @@ type NetConfig struct {
 // netConfigJSON defines the network configuration JSON file format for the vpc-bridge plugin.
 type netConfigJSON struct {
 	cniTypes.NetConf
+	// Options to be passed in by the runtime
+	RuntimeConfig RuntimeConfig `json:"runtimeConfig"`
+	// Other explicit options
 	ENIName          string   `json:"eniName"`
 	ENIMACAddress    string   `json:"eniMACAddress"`
 	ENIIPAddresses   []string `json:"eniIPAddresses"`
@@ -57,6 +61,13 @@ type netConfigJSON struct {
 	InterfaceType    string   `json:"interfaceType"`
 	TapUserID        string   `json:"tapUserID"`
 	ServiceCIDR      string   `json:"serviceCIDR"`
+}
+
+// RuntimeConfig are the runtime options which will be populated dynamically by the runtime
+// based on the requested capability.
+// https://www.cni.dev/docs/conventions/#dynamic-plugin-specific-fields-capabilities--runtime-configuration
+type RuntimeConfig struct {
+	PortMappings []vpc.PortMapping `json:"portMappings,omitempty"`
 }
 
 const (
@@ -107,6 +118,7 @@ func New(args *cniSkel.CmdArgs, isAddCmd bool) (*NetConfig, error) {
 		BridgeType:      config.BridgeType,
 		BridgeNetNSPath: config.BridgeNetNSPath,
 		InterfaceType:   config.InterfaceType,
+		PortMappings:    config.RuntimeConfig.PortMappings,
 	}
 
 	// Parse the ENI MAC address.

--- a/plugins/vpc-bridge/network/network.go
+++ b/plugins/vpc-bridge/network/network.go
@@ -30,6 +30,7 @@ type Builder interface {
 // Network represents a container network.
 type Network struct {
 	Name                string
+	NetworkID           string
 	BridgeType          string
 	BridgeNetNSPath     string
 	BridgeIndex         int

--- a/plugins/vpc-bridge/network/network.go
+++ b/plugins/vpc-bridge/network/network.go
@@ -17,6 +17,7 @@ import (
 	"net"
 
 	"github.com/aws/amazon-vpc-cni-plugins/network/eni"
+	"github.com/aws/amazon-vpc-cni-plugins/network/vpc"
 )
 
 // Builder knows how to build container networks and connect container network interfaces.
@@ -45,11 +46,12 @@ type Network struct {
 
 // Endpoint represents a container network interface.
 type Endpoint struct {
-	ContainerID string
-	NetNSName   string
-	IfName      string
-	IfType      string
-	TapUserID   int
-	MACAddress  net.HardwareAddr
-	IPAddresses []net.IPNet
+	ContainerID  string
+	NetNSName    string
+	IfName       string
+	IfType       string
+	TapUserID    int
+	MACAddress   net.HardwareAddr
+	IPAddresses  []net.IPNet
+	PortMappings []vpc.PortMapping
 }

--- a/plugins/vpc-bridge/plugin/commands.go
+++ b/plugins/vpc-bridge/plugin/commands.go
@@ -79,12 +79,13 @@ func (plugin *Plugin) Add(args *cniSkel.CmdArgs) error {
 
 	// Find or create the container endpoint on the network.
 	ep := network.Endpoint{
-		ContainerID: args.ContainerID,
-		NetNSName:   args.Netns,
-		IfName:      args.IfName,
-		IfType:      netConfig.InterfaceType,
-		TapUserID:   netConfig.TapUserID,
-		IPAddresses: netConfig.IPAddresses,
+		ContainerID:  args.ContainerID,
+		NetNSName:    args.Netns,
+		IfName:       args.IfName,
+		IfType:       netConfig.InterfaceType,
+		TapUserID:    netConfig.TapUserID,
+		IPAddresses:  netConfig.IPAddresses,
+		PortMappings: netConfig.PortMappings,
 	}
 
 	err = nb.FindOrCreateEndpoint(&nw, &ep)


### PR DESCRIPTION
## Summary
`vpc-bridge` CNI plugin (previously known as `vpc-shared-eni`) is used for networking on Windows nodes running in EKS. Presently, we do not support container to host port mapping using this CNI plugin. Therefore, `vpc-bridge` plugin silently ignores any port mapping between container to host for the configured endpoint.

As per the CNI convention, plugins can request that the runtime insert this dynamic configuration by explicitly listing their capabilities in the network configuration. Dynamic information (i.e. data that a runtime fills out) should be placed in a runtimeConfig section. 
Reference: https://www.cni.dev/docs/conventions/#dynamic-plugin-specific-fields-capabilities--runtime-configuration

`portMappings` is one such capability.

In order to support host port usage, we need to add the appropriate policy during the HNS Endpoint creation.
However, as communicated in https://github.com/microsoft/Windows-Containers/issues/360, we need to use HNS V2 for creating this endpoint policy. Therefore in this PR, we will enhance the `vpc-bridge` CNI plugin to predominantly use `HNS V2` and also add support for host port mappings.


## Description of changes:
we are making the following changes-

- We will change the `vpc-bridge` CNI plugin to be HNS V2 first. This means that we will only use `HNS V1` APIs for attaching the endpoint to the container when using `docker` runtime.
  - The HNS network would be created using V2 APIs
  - The endpoint would be created using V2 APIs
  - The Network and Endpoint policies would be V2 policies
- We will add the `RuntimeConfig` using which CNI plugin can obtain the configured port mapping
- We will add the appropriate policies to apply the port mappings.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
