### PR TITLE
windows: use Search instead of Domain for DNS settings

### DIFF
--- a/plugins/vpc-bridge/network/bridge_windows.go
+++ b/plugins/vpc-bridge/network/bridge_windows.go
@@ -198,7 +198,7 @@ func (nb *BridgeBuilder) FindOrCreateEndpoint(nw *Network, ep *Endpoint) error {
 		HostComputeNetwork: nw.NetworkID,
 		IpConfigurations:   nil,
 		Dns: hcn.Dns{
-			Domain:     strings.Join(nw.DNSSuffixSearchList, ","),
+			Search:     nw.DNSSuffixSearchList,
 			ServerList: nw.DNSServers,
 		},
 		SchemaVersion: hcn.SchemaVersion{


### PR DESCRIPTION
## Summary
This is a bug fix in the `vpc-bridge` CNI plugin for Windows where we need to use `Search` parameter in `DNS` configuration for setting multiple domains used for short hostname lookups. Earlier we were using `Domain` which is a single string.

This change fixes this issue.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
