### PR TITLE
vpc-bridge plugin use hard-coded path to k8s connector binary

### DIFF
--- a/plugins/vpc-bridge/README.md
+++ b/plugins/vpc-bridge/README.md
@@ -2,5 +2,4 @@
 vpc-bridge CNI plugin for EKS Windows.
 
 ## Pre-requisites for running vpc-bridge CNI plugin for EKS Windows
-1. Env variable  `AWS_VPC_CNI_K8S_CONNECTOR_BINARY_PATH` is required to be set. This will be already set in EKS Windows Optimized AMIs.
-Set env variable `AWS_VPC_CNI_K8S_CONNECTOR_BINARY_PATH` to `C:\Program Files\Amazon\EKS\bin\aws-vpc-cni-k8s-connector.exe`.
+1. `vpc-bridge` CNI plugin depends on `C:\Program Files\Amazon\EKS\bin\aws-vpc-cni-k8s-connector.exe` for EKS Windows.

--- a/plugins/vpc-bridge/config/k8s/connector.go
+++ b/plugins/vpc-bridge/config/k8s/connector.go
@@ -26,8 +26,6 @@ import (
 )
 
 const (
-	// Represents Env variable for k8s connector binary path.
-	envK8sConnectorBinaryPath = "AWS_VPC_CNI_K8S_CONNECTOR_BINARY_PATH"
 	// Represents default path for k8s connector binary in EKS Windows AMIs.
 	defaultK8sConnectorBinaryPath = `C:\Program Files\Amazon\EKS\bin\aws-vpc-cni-k8s-connector.exe`
 
@@ -104,11 +102,7 @@ func executeK8sConnector(ctx context.Context, podNamespace string, podName strin
 
 // getK8sConnectorBinaryPath returns path to k8s connector binary.
 func getK8sConnectorBinaryPath() string {
-	connectorBinaryPath := os.Getenv(envK8sConnectorBinaryPath)
-	if connectorBinaryPath == "" {
-		connectorBinaryPath = defaultK8sConnectorBinaryPath
-	}
-	return connectorBinaryPath
+	return defaultK8sConnectorBinaryPath
 }
 
 // getK8sConnectorLogLevel returns the log level for k8s connector binary.


### PR DESCRIPTION

*Issue #, if available:*
Lower privilege user on Windows can change path to binary in `AWS_VPC_CNI_K8S_CONNECTOR_BINARY_PATH` env variable to execute unintended binary with highest privilege.

*Description of changes:*
Removing env variable AWS_VPC_CNI_K8S_CONNECTOR_BINARY_PATH which was used by CNI to get path to connector binary. CNI plugin will use hard-coded path to binary and execute it i.e. `C:\Program Files\Amazon\EKS\bin\aws-vpc-cni-k8s-connector.exe`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
