### PR TITLE
Deflake integration tests and dynamically create test interface for vpc-eni tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,9 +29,9 @@ jobs:
           sudo ip link set dev eth2 mtu 9001
           sudo ip link set dev eth2 up
           ip link show
-          sudo ip link add vpc-eni-test-1 type dummy
-          sudo ip link add vpc-eni-test-2 type dummy
-          sudo ip link add vpc-eni-test-3 type dummy
+          sudo ip link add eth3 type dummy
+          sudo ip link set dev eth3 mtu 9001
+          sudo ip link set dev eth3 up
           ip link show
       - name: test
         run: make e2e-test

--- a/plugins/vpc-eni/e2eTests/e2e_test.go
+++ b/plugins/vpc-eni/e2eTests/e2e_test.go
@@ -341,7 +341,7 @@ func createTestInterface(t *testing.T, linkName string) netlink.Link {
 	return link
 }
 
-// generateMACAddress generates a random locally-administrated MAC address.
+// generateMACAddress generates a random MAC address.
 func generateMACAddress() (net.HardwareAddr, error) {
 	buf := make([]byte, 6)
 	var mac net.HardwareAddr

--- a/plugins/vpc-tunnel/e2eTests/e2e_test.go
+++ b/plugins/vpc-tunnel/e2eTests/e2e_test.go
@@ -40,7 +40,7 @@ const (
 	geneveIPv4Address  = "169.254.0.1/31"
 	gatewayIPv4Address = "169.254.0.0"
 	destinationIP      = "10.0.2.129"
-	trunkName          = "eth1"
+	trunkName          = "eth3"
 	destinationPort    = 6081
 	primary            = "true"
 	netConfJsonFmt     = `


### PR DESCRIPTION
This PR makes the following two changes.

## Deflaking e2e tests
e2e tests are flaky because vpc-tunnel plugin's tests and vpc-branch-eni plugin's tests both use `eth2` test interface causing conflicts. This PR fixes this flakiness by creating a new `eth3` test interface and by making vpc-tunnel plugin use `eth3` test interface. 

## Dynamic creation and cleanup of test interface for vpc-eni plugin tests 
vpc-eni plugin tests (and other e2e tests) assume that test interfaces are already set up. This PR replaces this assumption in the tests by adding dynamic test interface creation and cleanup capability. This is better as the test runner (either human or CI) no longer needs to maintain the test interfaces for vpc-eni tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
